### PR TITLE
Explicitly specify test DLL

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,5 +30,6 @@ steps:
 
 - task: VSTest@2
   inputs:
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: '**\TestBots.dll'
+    searchFolder: '$(System.DefaultWorkingDirectory)'


### PR DESCRIPTION
Fixes "Could not find testhost" errors per https://stackoverflow.com/questions/71955269/vstest2-error-could-not-find-testhost-azure-pipelines