### PR TITLE
Bridge defensive fixes

### DIFF
--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -159,6 +159,26 @@ S5 -  -  S8
 HJ H2 H4 HQ
 C2 -  -  SA
 
+% Trump in if dummy hasn't played and we can see they have high
+
+[Event "2nd Hand Defense: Trump in if dummy is next and has high"]
+[Deal "N:.JT985.J432.T432 AT9.432.KQ765.98 - -"]
+[Contract "2C"]
+[Play "N"]
+HJ H2 H4 HQ
+C2 -  -  S3
+
+% Trump in if partner is void in suit and trump
+
+[Event "2nd Hand Defense: Trump in if partner is void in suit and trump"]
+[Deal "N:Q.JT98.J432.T432 KT9.432.KQ765.98 - -"]
+[Contract "2C"]
+[Play "N"]
+HJ H2 H4 HQ
+C2 C8 H5 CA
+SQ S9 H6 SA
+C3 -  -  S3
+
 % If an honor is led, cover with an honor (so if they lead the J, cover with the Q)
 
 [Event "2nd Hand Defense: Cover led honor"]

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -179,6 +179,18 @@ C2 C8 H5 CA
 SQ S9 H6 SA
 C3 -  -  S3
 
+% Other defensive rules against both suit and notrump:
+% If dummy has a long side suit that will be good (AKQxx or AQJ10xx),
+% and the player behind dummy does not have K,
+% try to win tricks quickly
+
+[Event "2nd Hand Defense: Win tricks quickly if dummy has long, good side suit"]
+[Deal "N:654.AQ.J432.T532 QJT.K9.AKQ87.987 - -"]
+[Contract "2S"]
+[Play "N"]
+C2 C7 CK CA
+HA -  -  H5
+
 % If an honor is led, cover with an honor (so if they lead the J, cover with the Q)
 
 [Event "2nd Hand Defense: Cover led honor"]
@@ -253,6 +265,18 @@ C2 CT C4 C3
 [Contract "3NT"]
 [Play "S"]
 H2 H3 HJ -
+
+% Other defensive rules against both suit and notrump:
+% If dummy has a long side suit that will be good (AKQxx or AQJ10xx),
+% and the player behind dummy does not have K,
+% try to win tricks quickly
+
+[Event "3rd Hand Defense: Win tricks quickly if dummy has long, good side suit"]
+[Deal "N:654.AQ.J432.T532 QJT.K9.AKQ87.987 - -"]
+[Contract "2S"]
+[Play "N"]
+C2 C7 CA CK
+HA -  H3 H7
 
 % If you have touching honors, play the lower one
 

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -171,7 +171,7 @@ C2 -  -  S3
 % Trump in if partner is void in suit and trump
 
 [Event "2nd Hand Defense: Trump in if partner is void in suit and trump"]
-[Deal "N:Q.JT98.J432.T432 KT9.432.KQ765.98 - -"]
+[Deal "N:Q.JT98.J432.T432 T98.432.KQ765.98 - -"]
 [Contract "2C"]
 [Play "N"]
 HJ H2 H4 HQ

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -179,6 +179,17 @@ C2 C8 H5 CA
 SQ S9 H6 SA
 C3 -  -  S3
 
+% General principle: if you have a trick that is now good as the defender,
+% and it is the "setting trick" aka the trick to defeat the contract,
+% take it.
+
+[Event "2nd Hand Defense: Take the setting trick"]
+[Deal "N:65.K65.AJ32.T532 - - JT98.987.987.A87"]
+[Contract "7NT"]
+[Play "S"]
+CK CA C2 C4
+-  D7 DA -
+
 % Other defensive rules against both suit and notrump:
 % If dummy has a long side suit that will be good (AKQxx or AQJ10xx),
 % and the player behind dummy does not have K,
@@ -265,6 +276,17 @@ C2 CT C4 C3
 [Contract "3NT"]
 [Play "S"]
 H2 H3 HJ -
+
+% General principle: if you have a trick that is now good as the defender,
+% and it is the "setting trick" aka the trick to defeat the contract,
+% take it.
+
+[Event "3rd Hand Defense: Take the setting trick"]
+[Deal "N:65.K65.AJ32.T532 - - JT98.987.987.A87"]
+[Contract "7NT"]
+[Play "S"]
+CK C7 C2 C4
+D4 D7 DA -
 
 % Other defensive rules against both suit and notrump:
 % If dummy has a long side suit that will be good (AKQxx or AQJ10xx),

--- a/TestBots/Bridge/TestBridgeBot.cs
+++ b/TestBots/Bridge/TestBridgeBot.cs
@@ -247,7 +247,10 @@ namespace TestBots
                 {
                     var card = trick[j];
                     var seat = (nextSeat + j) % 4;
+                    var player = players[seat];
                     cardsPlayedInOrder += $"{seat}{card}";
+                    if (j > 0 && card[1] != trick[0][1])
+                        player.VoidSuits.Add(LetterToSuit[trick[0][1]]);
                 }
                 if (trick.Count == 4)
                 {

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -769,6 +769,11 @@ namespace Trickster.Bots
                 var isDummyLHO = dummy.Seat == GetNextSeatAfter(state.player.Seat, state.players.Count);
                 if (isDummyLHO && IsCardHigh(dummyCardsInSuit.Last(), state.cardsPlayed))
                     return legalTrump.First();
+
+                // Trump in if partner is void in suit and trump
+                var partner = GetPartner(state);
+                if (partner.VoidSuits.Contains(ledCard.suit) && partner.VoidSuits.Contains(state.trumpSuit))
+                    return legalTrump.First();
             }
 
             // If an honor is led, cover with an honor (so if they lead the J, cover with the Q)


### PR DESCRIPTION
Fix #87

In general, the bot should avoid playing high cards immediately on defense to try to force the declaring team to play their high cards. However, there are a number of exceptions where the bot should play high or ruff to avoid losing too many tricks.

This change adds the following additional exceptions to the general rule, so the bot plays high and ruffs more often on defense:
* [x] Ruff in 2nd seat if dummy plays next and has high
* [x] Ruff in 2nd seat if partner is known void in both led suit and trump
* [x] Take tricks quickly in any seat if dummy has long, good side suit
* [x] Take the last sure tricks to defeat the contract from any seat