### PR TITLE
Bridge defensive fixes (take 2)

### DIFF
--- a/TestBots/Bridge/Fuzz.cs
+++ b/TestBots/Bridge/Fuzz.cs
@@ -159,6 +159,7 @@ namespace TestBots.Bridge
                     var card = legalCards[random.Next(legalCards.Count)];
                     trick += card;
                     plays.Add(card);
+                    hand.Remove(card);
 
                     var rank = PBN.CardRanks.IndexOf(card[0]);
                     var topRank = PBN.CardRanks.IndexOf(topCard[0]);
@@ -191,6 +192,7 @@ namespace TestBots.Bridge
                     ledSuit = card[1];
                     nextPlaySeat = (nextPlaySeat + 1) % 4;
                     plays.Add(card);
+                    hand.Remove(card);
                 }
             }
             return plays.ToArray();

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -159,6 +159,49 @@ S5 -  -  S8
 HJ H2 H4 HQ
 C2 -  -  SA
 
+% Trump in if dummy hasn't played and we can see they have high
+
+[Event "2nd Hand Defense: Trump in if dummy is next and has high"]
+[Deal "N:.JT985.J432.T432 AT9.432.KQ765.98 - -"]
+[Contract "2C"]
+[Play "N"]
+HJ H2 H4 HQ
+C2 -  -  S3
+
+% Trump in if partner is void in suit and trump
+
+[Event "2nd Hand Defense: Trump in if partner is void in suit and trump"]
+[Deal "N:Q.JT98.J432.T432 T98.432.KQ765.98 - -"]
+[Contract "2C"]
+[Play "N"]
+HJ H2 H4 HQ
+C2 C8 H5 CA
+SQ S9 H6 SA
+C3 -  -  S3
+
+% General principle: if you have a trick that is now good as the defender,
+% and it is the "setting trick" aka the trick to defeat the contract,
+% take it.
+
+[Event "2nd Hand Defense: Take the setting trick"]
+[Deal "N:65.K65.AJ32.T532 - - JT98.987.987.A87"]
+[Contract "7NT"]
+[Play "S"]
+CK CA C2 C4
+-  D7 DA -
+
+% Other defensive rules against both suit and notrump:
+% If dummy has a long side suit that will be good (AKQxx or AQJ10xx),
+% and the player behind dummy does not have K,
+% try to win tricks quickly
+
+[Event "2nd Hand Defense: Win tricks quickly if dummy has long, good side suit"]
+[Deal "N:654.AQ.J432.T532 QJT.K9.AKQ87.987 - -"]
+[Contract "2S"]
+[Play "N"]
+C2 C7 CK CA
+HA -  -  H5
+
 % If an honor is led, cover with an honor (so if they lead the J, cover with the Q)
 
 [Event "2nd Hand Defense: Cover led honor"]
@@ -233,6 +276,29 @@ C2 CT C4 C3
 [Contract "3NT"]
 [Play "S"]
 H2 H3 HJ -
+
+% General principle: if you have a trick that is now good as the defender,
+% and it is the "setting trick" aka the trick to defeat the contract,
+% take it.
+
+[Event "3rd Hand Defense: Take the setting trick"]
+[Deal "N:65.K65.AJ32.T532 - - JT98.987.987.A87"]
+[Contract "7NT"]
+[Play "S"]
+CK C7 C2 C4
+D4 D7 DA -
+
+% Other defensive rules against both suit and notrump:
+% If dummy has a long side suit that will be good (AKQxx or AQJ10xx),
+% and the player behind dummy does not have K,
+% try to win tricks quickly
+
+[Event "3rd Hand Defense: Win tricks quickly if dummy has long, good side suit"]
+[Deal "N:654.AQ.J432.T532 QJT.K9.AKQ87.987 - -"]
+[Contract "2S"]
+[Play "N"]
+C2 C7 CA CK
+HA -  H3 H7
 
 % If you have touching honors, play the lower one
 

--- a/TestBots/Bridge/TestBridgeBot.cs
+++ b/TestBots/Bridge/TestBridgeBot.cs
@@ -247,7 +247,10 @@ namespace TestBots
                 {
                     var card = trick[j];
                     var seat = (nextSeat + j) % 4;
+                    var player = players[seat];
                     cardsPlayedInOrder += $"{seat}{card}";
+                    if (j > 0 && card[1] != trick[0][1])
+                        player.VoidSuits.Add(LetterToSuit[trick[0][1]]);
                 }
                 if (trick.Count == 4)
                 {

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -774,9 +774,8 @@ namespace Trickster.Bots
                     return legalTrump.First();
 
                 // Trump in if dummy plays next and has high
-                var dummyHighCardInSuit = dummyCardsInSuit.LastOrDefault();
                 var isDummyLHO = dummy.Seat == GetNextSeatAfter(state.player.Seat, state.players.Count);
-                if (isDummyLHO && IsCardHigh(dummyCardsInSuit.Last(), state.cardsPlayed))
+                if (isDummyLHO && dummyCardsInSuit.Any() && IsCardHigh(dummyCardsInSuit.Last(), state.cardsPlayed))
                     return legalTrump.First();
 
                 // Trump in if partner is void in suit and trump

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -379,12 +379,22 @@ namespace Trickster.Bots
                 var lho = state.players.Single(p => p.Seat == (state.player.Seat + 1) % state.players.Count);
                 var rho = state.players.Single(p => p.Seat == (state.player.Seat - 1 + state.players.Count) % state.players.Count);
 
-                // Don't count off suit boss cards if opponents still have trump
-                if (!lho.VoidSuits.Contains(state.trumpSuit) || !rho.VoidSuits.Contains(state.trumpSuit))
+                // Don't count off suit boss cards if opponents still have trump (excluding those who have already played to the trick)
+                if (!lho.VoidSuits.Contains(state.trumpSuit) || (state.trick.Count == 0 && !rho.VoidSuits.Contains(state.trumpSuit)))
                     bossCards = bossCards.Where(c => c.suit == state.trumpSuit);
             }
 
             return bossCards.ToList();
+        }
+
+        private int GetTricksNeededToSet(SuggestCardState<BridgeOptions> state)
+        {
+            var declarer = GetDeclarer(state);
+            var partner = GetPartner(state);
+            var level = new DeclareBid(declarer.Bid).level;
+            var takenTricks = state.player.CardsTaken.Length / 8 + partner.CardsTaken.Length / 8;
+            var neededTricksToSet = 14 - (level + 6) - takenTricks;
+            return neededTricksToSet;
         }
 
         private int AdjustedRank(Card card, IReadOnlyList<Card> played)
@@ -433,6 +443,25 @@ namespace Trickster.Bots
             var interpretedHistory = InterpretedBid.InterpretHistory(history);
             var unbidSuits = SuitRank.stdSuits.Where(suit => interpretedHistory.All(b => b.HandShape[suit].Min <= 2));
             return unbidSuits.ToList();
+        }
+
+        private bool DummyHasLongGoodSideSuit(SuggestCardState<BridgeOptions> state)
+        {
+            // If dummy has a long side suit that will be good, like AKQxx,
+            // TODO: or AQJTxx (when the player behind dummy does not have K),
+            //       try to take tricks quickly
+            // Note: only applies with one missing honor (K or Q)
+            var dummyHand = new Hand(GetDummy(state).Hand);
+            var knownCards = dummyHand.Concat(state.cardsPlayed).ToList();
+            var sideSuits = SuitRank.stdSuits.Where(s => s != state.trumpSuit);
+            var goodSideSuits = sideSuits.Where(s =>
+            {
+                var cardsInSuit = dummyHand.Where(c => c.suit == s);
+                var hasEnoughLength = cardsInSuit.Count() >= 5;
+                var hasEnoughStrength = cardsInSuit.Count(c => IsCardHigh(c, knownCards)) >= 3;
+                return hasEnoughLength && hasEnoughStrength;
+            });
+            return goodSideSuits.Any();
         }
 
         private Card LeadAceOrLowOrFourthBest(List<Card> cards)
@@ -642,34 +671,14 @@ namespace Trickster.Bots
             // General principle: if you have a trick that is now good as the defender,
             // and it is the "setting trick" aka the trick to defeat the contract,
             // take it.
-            var declarer = GetDeclarer(state);
-            var partner = GetPartner(state);
-            var level = new DeclareBid(declarer.Bid).level;
-            var takenTricks = state.player.CardsTaken.Length / 8 + partner.CardsTaken.Length / 8;
-            var neededTricksToSet = 14 - (level + 6) - takenTricks;
+            int tricksNeededToSet = GetTricksNeededToSet(state);
             var sureWinners = GetSureWinners(state);
-            if (sureWinners.Any() && sureWinners.Count() >= neededTricksToSet)
+            if (sureWinners.Any() && sureWinners.Count() >= tricksNeededToSet)
                 return sureWinners.First();
 
-            // Other defensive rules against both suit and notrump:
-
-            // If dummy has a long side suit that will be good, like AKQxx,
-            // try to win tricks quickly
-            var knownCards = dummyHand.Concat(state.cardsPlayed).ToList();
-            var sideSuits = SuitRank.stdSuits.Where(s => s != state.trumpSuit);
-            var goodSideSuits = sideSuits.Where(s =>
-            {
-                var cardsInSuit = dummyHand.Where(c => c.suit == s);
-                var hasEnoughLength = cardsInSuit.Count() >= 5;
-                var hasEnoughStrength = cardsInSuit.Count(c => IsCardHigh(c, knownCards)) >= 3;
-                return hasEnoughLength && hasEnoughStrength;
-            });
-            if (goodSideSuits.Any())
+            // try to win tricks quickly if dummy has a long, good side suit
+            if (DummyHasLongGoodSideSuit(state))
                 return TryTakeEm(state);
-
-            // TODO: or AQJ10xx (when the player behind dummy does not have K),
-            //       try to take tricks quickly
-            // Note: only applies with one missing honor (K or Q)
 
             // Leads after trick 1: same general rules apply (playing touching honors, etc).
             // * Give priority to returning partner's suit (especially in NT),
@@ -752,13 +761,41 @@ namespace Trickster.Bots
         private Card SuggestSecondHandDefensivePlay(SuggestCardState<BridgeOptions> state)
         {
             var ledCard = state.trick[0];
+            var dummy = GetDummy(state);
+            var dummyCardsInSuit = new Hand(dummy.Hand).Where(c => c.suit == ledCard.suit).OrderBy(c => c.rank).ToList();
             Card coverHonor = null;
 
-            // Trump in if the first card played is known to be high
+            // If we can trump in...
             var legalTrump = state.legalCards.Where(c => c.suit == state.trumpSuit).OrderBy(c => c.rank);
-            var dummyCardsInSuit = new Hand(GetDummy(state).Hand).Where(c => c.suit == ledCard.suit).ToList();
-            if (legalTrump.Any() && ledCard.suit != state.trumpSuit && IsCardHigh(ledCard, dummyCardsInSuit.Concat(state.cardsPlayed)))
-                return legalTrump.First();
+            if (ledCard.suit != state.trumpSuit && legalTrump.Any())
+            {
+                // Trump in if the first card played is high
+                if (IsCardHigh(ledCard, dummyCardsInSuit.Concat(state.cardsPlayed)))
+                    return legalTrump.First();
+
+                // Trump in if dummy plays next and has high
+                var dummyHighCardInSuit = dummyCardsInSuit.LastOrDefault();
+                var isDummyLHO = dummy.Seat == GetNextSeatAfter(state.player.Seat, state.players.Count);
+                if (isDummyLHO && IsCardHigh(dummyCardsInSuit.Last(), state.cardsPlayed))
+                    return legalTrump.First();
+
+                // Trump in if partner is void in suit and trump
+                var partner = GetPartner(state);
+                if (partner.VoidSuits.Contains(ledCard.suit) && partner.VoidSuits.Contains(state.trumpSuit))
+                    return legalTrump.First();
+            }
+
+            // General principle: if you have a trick that is now good as the defender,
+            // and it is the "setting trick" aka the trick to defeat the contract,
+            // take it.
+            int tricksNeededToSet = GetTricksNeededToSet(state);
+            var sureWinners = GetSureWinners(state);
+            if (sureWinners.Any() && sureWinners.Count() >= tricksNeededToSet)
+                return sureWinners.First();
+
+            // try to win tricks quickly if dummy has a long, good side suit
+            if (DummyHasLongGoodSideSuit(state))
+                return TryTakeEm(state);
 
             // If an honor is led, cover with an honor (so if they lead the J, cover with the Q)
             if (ledCard.rank >= Rank.Ten)
@@ -835,14 +872,30 @@ namespace Trickster.Bots
             if (isDummyRHO)
                 knownCards = knownCards.Concat(dummyHand).ToList();
 
-            // If partner is winning with an honor, play low
-            if (state.isPartnerTakingTrick && state.cardTakingTrick.rank >= Rank.Ten)
+            // If partner is winning with a high card, play low
+            if (state.isPartnerTakingTrick && IsCardHigh(state.cardTakingTrick, knownCards))
                 return SuggestDefensiveDiscard(state);
 
             // If 4th seat is void, we should play low if partner is winning
             var fourthSeatPlayer = state.players.Single(p => p.Seat == GetNextSeat(state));
             var isFourthSeatVoid = fourthSeatPlayer.VoidSuits.Contains(state.cardTakingTrick.suit);
             if (state.isPartnerTakingTrick && isFourthSeatVoid)
+                return SuggestDefensiveDiscard(state);
+
+            // General principle: if you have a trick that is now good as the defender,
+            // and it is the "setting trick" aka the trick to defeat the contract,
+            // take it.
+            int tricksNeededToSet = GetTricksNeededToSet(state);
+            var sureWinners = GetSureWinners(state);
+            if (sureWinners.Any() && sureWinners.Count() >= tricksNeededToSet)
+                return sureWinners.First();
+
+            // try to win tricks quickly if dummy has a long, good side suit
+            if (DummyHasLongGoodSideSuit(state))
+                return TryTakeEm(state);
+
+            // If partner is winning with an honor, play low
+            if (state.isPartnerTakingTrick && state.cardTakingTrick.rank >= Rank.Ten)
                 return SuggestDefensiveDiscard(state);
 
             // If dummy has Qxx, and you play third after dummy plays a low card from KJx, you'd play J.


### PR DESCRIPTION
Fix #87

In general, the bot should avoid playing high cards immediately on defense to try to force the declaring team to play their high cards. However, there are a number of exceptions where the bot should play high or ruff to avoid losing too many tricks.

This change adds the following additional exceptions to the general rule, so the bot plays high and ruffs more often on defense:
* [x] Ruff in 2nd seat if dummy plays next and has high
* [x] Ruff in 2nd seat if partner is known void in both led suit and trump
* [x] Take tricks quickly in any seat if dummy has long, good side suit
* [x] Take the last sure tricks to defeat the contract from any seat

This version fixes a "Sequence contains no element" error that happened when dummy was void in the led suit. It also updates the fuzzer to ensure we catch similar conditions in the future.