### PR TITLE
More bridge defensive play improvements

### DIFF
--- a/TestBots/Bridge/Fuzz.cs
+++ b/TestBots/Bridge/Fuzz.cs
@@ -104,7 +104,7 @@ namespace TestBots.Bridge
             {
                 if (bids[i][1] == contract[1])
                 {
-                    declarerSeat = i;
+                    declarerSeat = i % 4;
                     break;
                 }
             }

--- a/TestBots/Bridge/PBN.cs
+++ b/TestBots/Bridge/PBN.cs
@@ -155,7 +155,7 @@ namespace TestBots.Bridge
 
                 for (var j = 0; j < suits.Length; j++)
                     foreach (var card in suits[j])
-                        hand += $"{card}{SuitLetters[j]}";
+                        hand = $"{card}{SuitLetters[j]}" + hand; // Put high cards on right to match Trickster Cards production behavior
 
                 hands[seat] = hand;
             }

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -262,6 +262,16 @@ S4 SJ SQ SA
 C2 CT C4 C3
 -  ST SK -
 
+% Don't play below dummy if dummy has a singleton
+
+[Event "2nd Hand Defense: Play above visible singleton in dummy"]
+[Deal "S:K98.KJT6.AK6532. - - A654.A753.87.853"]
+[Contract "3H"]
+[Play "E"]
+C3 S8 CJ CK
+C5 S9 C2 CA
+SA -  -  S2
+
 
 
 %
@@ -351,6 +361,12 @@ H9 H3 HQ -
 [Play "S"]
 H3 H4 H5 -
 
+[Event "3rd Hand Defense: Cover second card if it's winning (case 2)"]
+[Deal "N:- - Q976.K62.AKQJ3.T AJT.AJ.T5.J86542"]
+[Contract "4S"]
+[Play "E"]
+C7 CT CJ -
+
 % If the second card played will win the trick, trump in if possible.
 
 [Event "3rd Hand Defense: Trump in over second card if it's winning"]
@@ -358,3 +374,9 @@ H3 H4 H5 -
 [Contract "3S"]
 [Play "S"]
 H3 H4 S7 -
+
+[Event "3rd Hand Defense: Play an honor after dummy if noone's played an honor to the trick"]
+[Deal "E:9643.Q5.9652.A98 - - KT82.74.KQJ4.743"]
+[Contract "4H"]
+[Play "W"]
+C5 C3 CA -

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -380,3 +380,10 @@ H3 H4 S7 -
 [Contract "4H"]
 [Play "W"]
 C5 C3 CA -
+
+[Event "3rd Hand Defense: Play low if we can't beat the card winning the trick"]
+[Deal "W:AQT7.J.AKQT2.T64 - - 9542.KT42.95.K98"]
+[Contract "1NT"]
+[Play "S"]
+H2 HJ HA H5
+C8 -  C2 CA

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -387,3 +387,10 @@ C5 C3 CA -
 [Play "S"]
 H2 HJ HA H5
 C8 -  C2 CA
+
+[Event "3rd Hand Defense: Play minimum winner if dummy is next and void"]
+[Deal "W:AQT7.J.AKQT2.T64 - - 9542.KT42.95.K98"]
+[Contract "1NT"]
+[Play "S"]
+H2 HJ HA H5
+HT -  H7 H8

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -287,6 +287,13 @@ SA -  -  S2
 [Play "S"]
 H2 H3 HJ -
 
+[Event "3rd Hand Defense: Play as high as necessary (RHO taking, dummy can't beat as LHO)"]
+[Deal "E:Q42.K75.AK83.764 753.3.QJ642.QT52 - -"]
+[Contract "3NT"]
+[Play "E"]
+D3 D2 DT D7
+HK -  H4 H8
+
 % General principle: if you have a trick that is now good as the defender,
 % and it is the "setting trick" aka the trick to defeat the contract,
 % take it.

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -120,10 +120,10 @@ D6 D7 DJ D5
 % take it.
 
 [Event "Lead on Defense: Take the setting trick"]
-[Deal "N:65.K65.AJ32.T532 - - JT98.987.987.987"]
+[Deal "N:65.K65.AK32.T532 - - JT98.987.987.987"]
 [Contract "6NT"]
 [Play "S"]
-D6 D7 DJ D5
+D6 D7 DK D5
 -  -  DA -
 
 % View AQ as a sequence once the K is played (and similar positions)

--- a/TestBots/Bridge/TestBridgeBot.cs
+++ b/TestBots/Bridge/TestBridgeBot.cs
@@ -231,8 +231,14 @@ namespace TestBots
             var players = new[] { new TestPlayer(), new TestPlayer(), new TestPlayer(), new TestPlayer() };
             for (var i = 0; i < 4; i++)
             {
-                players[i].Bid = i == 1 ? BidBase.Dummy : i % 2 == 0 ? BridgeBid.Defend : (int)contract;
-                players[i].Seat = (test.declarerSeat + 1 + i) % 4;
+                players[i].Seat = (test.declarerSeat + i) % 4;
+
+                if (players[i].Seat == test.declarerSeat)
+                    players[i].Bid = (int)contract;
+                else if (players[i].Seat == (test.declarerSeat + 2) % 4)
+                    players[i].Bid = BidBase.Dummy;
+                else
+                    players[i].Bid = BridgeBid.Defend;
             }
 
             // resort the players in seat order to simplify adding data

--- a/TestBots/Util.cs
+++ b/TestBots/Util.cs
@@ -68,9 +68,10 @@ namespace TestBots
             //  save the underlying list into our state
             this.players = playersCollection;
 
-            //  set the seats of the players
-            for (var seat = 0; seat < this.players.Count; ++seat)
-                this.players[seat].Seat = seat;
+            //  set the seats of the players if not already set
+            if (this.players.All(p => p.Seat == 0))
+                for (var seat = 0; seat < this.players.Count; ++seat)
+                    this.players[seat].Seat = seat;
 
             //  the "playing player" is assumed to be the first
             player = this.players[0];

--- a/TestBots/Util.cs
+++ b/TestBots/Util.cs
@@ -92,8 +92,7 @@ namespace TestBots
 
                 var highCardIndex = bot.TrickHighCardIndex(this.trick);
                 cardTakingTrick = this.trick[highCardIndex];
-                var seatTakingTrick =
-                    playersCollection.Count(p => p.Bid != BidBase.NotPlaying) - this.trick.Count + highCardIndex; // we assume it's seat 0's turn to play
+                var seatTakingTrick = SeatTakingTrick(bot, playersCollection, player);
                 isPartnerTakingTrick = playersCollection.PartnersOf(playersCollection[0]).Any(p => p.Seat == seatTakingTrick);
                 trickTaker = playersCollection.Single(p => p.Seat == seatTakingTrick);
 
@@ -114,6 +113,16 @@ namespace TestBots
 
             if (notLegalSuit != Suit.Unknown)
                 legalCards = legalCards.Where(c => bot.EffectiveSuit(c) != notLegalSuit).ToList();
+        }
+
+        private int SeatTakingTrick(IBaseBot bot, PlayersCollectionBase players, PlayerBase nextOrLastPlayer)
+        {
+            var highCardIndex = bot.TrickHighCardIndex(trick);
+            var activePlayers = players.Where(p => p.Bid != BidBase.NotPlaying && !p.Folded).OrderBy(p => p.Seat).ToList();
+            var nextOrLastPlayerIndex = activePlayers.IndexOf(nextOrLastPlayer);
+            var shift = trick.Count == activePlayers.Count ? 1 : 0; // shift by one if this is the last player
+            var firstPlayerIndex = (nextOrLastPlayerIndex + activePlayers.Count - trick.Count + shift) % activePlayers.Count;
+            return activePlayers[(firstPlayerIndex + highCardIndex) % activePlayers.Count].Seat;
         }
     }
 }

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -869,6 +869,14 @@ namespace Trickster.Bots
             if (isDummyRHO)
                 knownCards = knownCards.Concat(dummyHand).ToList();
 
+            // If we can't beat the best card in the trick, play low
+            if (EffectiveSuit(state.cardTakingTrick) == ledSuit && legalCardsInSuit.Any() && !legalCardsInSuit.Any(c => RankSort(c) > RankSort(state.cardTakingTrick)))
+                return SuggestDefensiveDiscard(state);
+
+            // If 2nd seat trumped in and we don't have any legal trump, play low
+            if (EffectiveSuit(state.cardTakingTrick) == state.trumpSuit && ledSuit != state.trumpSuit && !legalCards.Any(c => EffectiveSuit(c) == state.trumpSuit))
+                return SuggestDefensiveDiscard(state);
+
             // If partner is winning with a high card, play low
             if (state.isPartnerTakingTrick && IsCardHigh(state.cardTakingTrick, knownCards))
                 return SuggestDefensiveDiscard(state);

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -897,14 +897,16 @@ namespace Trickster.Bots
             if (state.isPartnerTakingTrick && isFourthSeatVoid)
                 return SuggestDefensiveDiscard(state);
 
-            // If partner is NOT winning and 4th seat is void, play lowest winner if possible
+            // If partner is NOT winning and 4th seat is void or cannot beat the best card in the trick, play lowest winner if possible
+            var isDummyLHO = GetNextSeat(state) == dummy.Seat;
+            var dummyBestCardInSuit = dummyHand.Where(c => EffectiveSuit(c) == ledSuit).FirstOrDefault();
+            var canLhoDummyWinTrick = isDummyLHO && dummyBestCardInSuit != null && EffectiveSuit(state.cardTakingTrick) == ledSuit && RankSort(dummyBestCardInSuit) > RankSort(state.cardTakingTrick);
+            var isFourthSeatUnder = isDummyLHO && !canLhoDummyWinTrick;
             var minimumWinner = legalCardsInWinningSuit.LastOrDefault(c => RankSort(c) > RankSort(state.cardTakingTrick));
-            if (!state.isPartnerTakingTrick && isFourthSeatVoid && minimumWinner != null)
+            if (!state.isPartnerTakingTrick && (isFourthSeatVoid || isFourthSeatUnder) && minimumWinner != null)
                 return minimumWinner;
 
             // If partner is winning, dummy is LHO, and partner's card is better than dummy's best, play low
-            var isDummyLHO = GetNextSeat(state) == dummy.Seat;
-            var dummyBestCardInSuit = dummyHand.Where(c => EffectiveSuit(c) == ledSuit).FirstOrDefault();
             if (state.isPartnerTakingTrick && isDummyLHO && (dummyBestCardInSuit == null || RankSort(state.cardTakingTrick) > RankSort(dummyBestCardInSuit)))
                 return SuggestDefensiveDiscard(state);
 

--- a/TricksterBots/Bots/PlayersCollectionBase.cs
+++ b/TricksterBots/Bots/PlayersCollectionBase.cs
@@ -29,7 +29,12 @@ namespace Trickster.Bots
 
         public bool LhoIsVoidInSuit(PlayerBase player, Card card, IEnumerable<Card> cardsPlayed)
         {
-            return TargetIsVoidInSuit(player, Lho(player), card, cardsPlayed);
+            return LhoIsVoidInSuit(player, gameBot.EffectiveSuit(card), cardsPlayed);
+        }
+
+        public bool LhoIsVoidInSuit(PlayerBase player, Suit suit, IEnumerable<Card> cardsPlayed)
+        {
+            return TargetIsVoidInSuit(player, Lho(player), suit, cardsPlayed);
         }
 
         public List<PlayerBase> Opponents(PlayerBase player)
@@ -78,15 +83,25 @@ namespace Trickster.Bots
 
         public bool RhoIsVoidInSuit(PlayerBase player, Card card, IEnumerable<Card> cardsPlayed)
         {
-            return TargetIsVoidInSuit(player, Rho(player), card, cardsPlayed);
+            return RhoIsVoidInSuit(player, gameBot.EffectiveSuit(card), cardsPlayed);
+        }
+
+        public bool RhoIsVoidInSuit(PlayerBase player, Suit suit, IEnumerable<Card> cardsPlayed)
+        {
+            return TargetIsVoidInSuit(player, Rho(player), suit, cardsPlayed);
         }
 
         public bool TargetIsVoidInSuit(PlayerBase player, PlayerBase target, Card card, IEnumerable<Card> cardsPlayed)
         {
-            if (gameBot.CanSeeHand(this, player, target))
-                return new Hand(target.Hand).All(c => gameBot.EffectiveSuit(c) != gameBot.EffectiveSuit(card));
+            return TargetIsVoidInSuit(player, target, gameBot.EffectiveSuit(card), cardsPlayed);
+        }
 
-            return target.VoidSuits.Contains(gameBot.EffectiveSuit(card)) || PlayerHasAllRemainingInSuit(player, card, cardsPlayed);
+        public bool TargetIsVoidInSuit(PlayerBase player, PlayerBase target, Suit suit, IEnumerable<Card> cardsPlayed)
+        {
+            if (gameBot.CanSeeHand(this, player, target))
+                return new Hand(target.Hand).All(c => gameBot.EffectiveSuit(c) != suit);
+
+            return target.VoidSuits.Contains(suit) || PlayerHasAllRemainingInSuit(player, suit, cardsPlayed);
         }
 
         private PlayerBase OppositeOf(PlayerBase player)
@@ -94,9 +109,8 @@ namespace Trickster.Bots
             return this.First(p => p.Seat == (player.Seat + Count / 2) % Count);
         }
 
-        private bool PlayerHasAllRemainingInSuit(PlayerBase player, Card card, IEnumerable<Card> cardsPlayed)
+        private bool PlayerHasAllRemainingInSuit(PlayerBase player, Suit suit, IEnumerable<Card> cardsPlayed)
         {
-            var suit = gameBot.EffectiveSuit(card);
             var totalCardsInSuit = DeckBuilder.BuildDeck(gameBot.DeckType).Count(c => gameBot.EffectiveSuit(c) == suit);
             return totalCardsInSuit ==
                    this.Where(p => gameBot.CanSeeHand(this, player, p)).Sum(p => new Hand(p.Hand).Count(c => gameBot.EffectiveSuit(c) == suit))


### PR DESCRIPTION
Fix #91 
Ref #94 

Notably this fixes cases where 3rd seat would play high, but not try to win the trick. The bot now more correctly plays as high as necessary, meaning it will try to win the trick but will watch for cases where it is safe to play a lower card and still win the trick.

Play from 2nd seat has also been improved to fall-through when trying to win tricks quickly if not holding any high cards. It also handles a new special-case of playing an Ace if dummy follows and will be forced to play a singleton King.

Lastly, logic for ruffing on defense has been simplified to do so in most cases when possible unless clearly not beneficial.

Also fixes some test infrastructure bugs where the state being provided wasn't quite correct.