### PR TITLE
Euchre: Protect the left on defense

### DIFF
--- a/TestBots/TestEuchreBot.cs
+++ b/TestBots/TestEuchreBot.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trickster.Bots;
 using Trickster.cloud;
@@ -112,7 +113,7 @@ namespace TestBots
         }
 
         [TestMethod]
-        public void DontTrumpWinningPartnerWhenOpppontsGoAlone()
+        public void DontTrumpWinningPartnerWhenOpponentsGoAlone()
         {
             var players = new[]
             {
@@ -146,6 +147,91 @@ namespace TestBots
             var cardState = new TestCardState<EuchreOptions>(bot, players, "9STSQS");
             var suggestion = bot.SuggestNextCard(cardState);
             Assert.AreEqual("KS", suggestion.ToString(), $"Suggested {suggestion.StdNotation}; expected KS");
+        }
+
+        [TestMethod]
+        public void ProtectTheLeftOnDefense()
+        {
+            var players = new[]
+            {
+                new TestPlayer(140, "ACTC9CJHQD"),
+                new TestPlayer(102),
+                new TestPlayer(140),
+                new TestPlayer(140),
+            };
+
+            var bot = GetBot(Suit.Diamonds);
+            var cardState = new TestCardState<EuchreOptions>(bot, players, "9SQS");
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("9C", $"{suggestion}");
+        }
+
+        [TestMethod]
+        public void DontProtectTheLeftWhenLastToPlay()
+        {
+            var players = new[]
+            {
+                new TestPlayer(140, "ACTC9CJHQD"),
+                new TestPlayer(102),
+                new TestPlayer(140),
+                new TestPlayer(140),
+            };
+
+            var bot = GetBot(Suit.Diamonds);
+            var cardState = new TestCardState<EuchreOptions>(bot, players, "9STSQS");
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("QD", $"{suggestion}");
+        }
+
+        [TestMethod]
+        public void DontProtectTheLeftWhenNextPlayerIsVoidInTrump()
+        {
+            var players = new[]
+            {
+                new TestPlayer(140, "AC9CJHQD"),
+                new TestPlayer(140) { VoidSuits = new List<Suit> { Suit.Diamonds } },
+                new TestPlayer(140),
+                new TestPlayer(102),
+            };
+
+            var bot = GetBot(Suit.Diamonds);
+            var cardState = new TestCardState<EuchreOptions>(bot, players, "9SQS");
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("QD", $"{suggestion}");
+        }
+
+        [TestMethod]
+        public void DontProtectTheLeftWith3PlusTrump()
+        {
+            var players = new[]
+            {
+                new TestPlayer(140, "ACTCJHQD9D"),
+                new TestPlayer(102),
+                new TestPlayer(140),
+                new TestPlayer(140),
+            };
+
+            var bot = GetBot(Suit.Diamonds);
+            var cardState = new TestCardState<EuchreOptions>(bot, players, "9SQS");
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("9D", $"{suggestion}");
+        }
+
+        [TestMethod]
+        public void DontProtectTheLeftIfHigh()
+        {
+            var players = new[]
+            {
+                new TestPlayer(140, "ACTC9CJHQD"),
+                new TestPlayer(140),
+                new TestPlayer(140),
+                new TestPlayer(102, cardsTaken: "JDQHTH9H"),
+            };
+
+            var bot = GetBot(Suit.Diamonds);
+            var cardState = new TestCardState<EuchreOptions>(bot, players, "9S");
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("QD", $"{suggestion}");
         }
 
         [TestMethod]

--- a/TricksterBots/Bots/Euchre/EuchreBot.cs
+++ b/TricksterBots/Bots/Euchre/EuchreBot.cs
@@ -203,6 +203,7 @@ namespace Trickster.Bots
             var playerBid = BidBid(player);
             var partnerIsMaker = players.PartnersOf(player).Any(p => BidBid(p) == EuchreBid.Make);
             var weAreMaker = playerBid == EuchreBid.Make || playerBid == EuchreBid.MakeAlone || partnerIsMaker;
+            var isDefending = !weAreMaker && !partnerIsMaker;
 
             var lowestCard = legalCards.OrderBy(c => IsTrump(c) ? 1 : 0).ThenBy(RankSort).First();
 
@@ -300,8 +301,11 @@ namespace Trickster.Bots
                 return lowestCard;
             }
 
-            //  we can't follow suit but we have trump
-            if (legalCards.Any(IsTrump))
+            //  we can't follow suit but we have trump (and don't need to protect the off jack)
+            var offJack = legalCards.FirstOrDefault(c => IsTrump(c) && c.rank == Rank.Jack && c.suit != trump);
+            var isLHOVoidInTrump = players.LhoIsVoidInSuit(player, trump, cardsPlayed);
+            var needToProtectOffJack = isDefending && !isLastToPlay && !isLHOVoidInTrump && offJack != null && !IsCardHigh(offJack, cardsPlayed) && legalCards.Count(IsTrump) == 2;
+            if (legalCards.Any(IsTrump) && !needToProtectOffJack)
             {
                 //  the trick already contains trump
                 if (trick.Any(IsTrump))


### PR DESCRIPTION
Fix #30

Updates the bot to avoid trumping in when holding the off-Jack and only one other trump (when the off-Jack isn't high, we're not the last to play to the trick, and LHO might still have trump).