### PR TITLE
Euchre: Lead high trump to maker if partner

### DIFF
--- a/TestBots/TestEuchreBot.cs
+++ b/TestBots/TestEuchreBot.cs
@@ -149,6 +149,23 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void LeadLeftToPartnerIfTheyCalled()
+        {
+            var players = new[]
+            {
+                new TestPlayer(140, "ACTC9CJHQD"),
+                new TestPlayer(140),
+                new TestPlayer(102),
+                new TestPlayer(140),
+            };
+
+            var bot = GetBot(Suit.Diamonds);
+            var cardState = new TestCardState<EuchreOptions>(bot, players);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("JH", $"{suggestion}");
+        }
+
+        [TestMethod]
         public void TestAvoidBid()
         {
             Assert.AreEqual("Pass", GetSuggestedBid(" 9C 9S 9HAHJD", "QH"), "Should pass if three-suited and weak, even with three trump");

--- a/TricksterBots/Bots/Euchre/EuchreBot.cs
+++ b/TricksterBots/Bots/Euchre/EuchreBot.cs
@@ -215,9 +215,8 @@ namespace Trickster.Bots
                 if (sortedTrump.Count > 0 && partnerIsMaker && cardsPlayed.Count(IsTrump) < 3)
                 {
                     //  we have a trump to play, our partner is the maker, and not much trump has been played thus far:
-                    //  lead our high trump if it's good or our low trump if not
-                    var highTrump = sortedTrump.Last();
-                    return IsCardHigh(highTrump, cardsPlayed) ? highTrump : sortedTrump.First();
+                    //  lead our highest trump to help partner
+                    return sortedTrump.Last();
                 }
 
                 //  Lead trump if you called it and have three or more trump


### PR DESCRIPTION
Fix #81

Only applies when not much trump has been played yet. In many situations (especially if our high card is the off-Jack) this enables our partner to duck the trick and save their high trump for later.