### PR TITLE
500: Keep Joker if Misère is yet to play

### DIFF
--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -114,6 +114,27 @@ namespace TestBots
             Assert.AreEqual("3D", $"{suggestion}");
         }
 
+
+        [TestMethod]
+        public void PlayUnderMisereIfPossibleWithJoker()
+        {
+            var players = new[]
+            {
+                new TestPlayer(FiveHundredBid.NotContractorBid, "HJKC3CTH9H8H7S4S3S2S"),
+                new TestPlayer(FiveHundredBid.Misere250Before8SBid, "0?0?0?0?0?0?0?0?0?0?"),
+                new TestPlayer(FiveHundredBid.NotContractorBid, "0?0?0?0?0?0?0?0?0?"),
+                new TestPlayer(BidBase.NotPlaying, "0?0?0?0?0?0?0?0?0?0?"),
+            };
+            var bot = GetBot(Suit.Unknown, defaultOptions);
+            var cardState = new TestCardState<FiveHundredOptions>(
+                bot,
+                players,
+                trick: "8D"
+            );
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("KC", $"{suggestion}");
+        }
+
         private static FiveHundredBot GetBot(Suit trumpSuit, FiveHundredOptions options)
         {
             return new FiveHundredBot(options, trumpSuit);

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -366,7 +366,7 @@ namespace Trickster.Bots
 
             //  if we're not leading, but a nullo player has yet to play, play low
             if (nulloPlayers.Any(p => p.Hand.Length == player.Hand.Length))
-                TryDumpEm(trick, legalCards, players.Count);
+                return TryDumpEm(trick, legalCards, players.Count);
 
             //  if a nullo player is taking the trick, try to get under them (but go high if we can't)
             if (nulloPlayers.Any(p => p.Seat == trickTaker.Seat))


### PR DESCRIPTION
Fix #106

Fixes a missing return statement that caused the bot to fall-through to playing high when defending against Misère if the Misère bidder hadn't played to the trick yet.