### PR TITLE
Bridge: Fix calculating sure tricks when current trick has trump

### DIFF
--- a/TestBots/Bridge/PBN.cs
+++ b/TestBots/Bridge/PBN.cs
@@ -99,7 +99,7 @@ namespace TestBots.Bridge
                                         dealerSeat = dealerSeat,
                                         declarerSeat = declarerSeat,
                                         history = history.ToArray(),
-                                        dummy = i > 0 ? hands[dummySeat] : "",
+                                        dummy = i > 0 ? seat == dummySeat ? hands[declarerSeat] : hands[dummySeat] : "",
                                         hand = hand,
                                         play = play,
                                         plays = plays.GetRange(0, i).ToArray(),

--- a/TestBots/Bridge/SAYC/Defensive Play.pbn
+++ b/TestBots/Bridge/SAYC/Defensive Play.pbn
@@ -272,6 +272,24 @@ C3 S8 CJ CK
 C5 S9 C2 CA
 SA -  -  S2
 
+[Event "2nd Hand Defense: Off-suit boss is not sure trick if trump played"]
+[Deal "E:KQ95.T82.JT97.QJ - - A732.Q543.KQ2.T7"]
+[Contract "3C"]
+[Auction "E"]
+Pass Pass 1C Pass
+1S Pass 2C Pass
+3C Pass Pass Pass
+[Play "N"]
+DK D7 D4 D3
+H3 H2 HJ HA
+C7 CJ C4 C2
+CT CQ C6 C3
+HQ H8 H6 H7
+H4 HT HK H9
+D2 D9 DA D6
+DQ DT D5 C5
+H5 -  -  CA
+
 
 
 %

--- a/TestBots/Bridge/TestBridgeBot.cs
+++ b/TestBots/Bridge/TestBridgeBot.cs
@@ -277,6 +277,8 @@ namespace TestBots
                     player.Hand = test.hand;
                 else if (player.Bid == BidBase.Dummy)
                     player.Hand = dummyHand;
+                else if (nextSeat == (player.Seat + 2) % 4 && players[(player.Seat + 2) % 4].Bid == BidBase.Dummy)
+                    player.Hand = dummyHand; // Show declarer's hand to dummy if it's dummy's turn to play
                 else // TODO: calculate correct length based on who's played in the current trick
                     player.Hand = UnknownCards(test.hand.Length / 2); 
             }

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -376,12 +376,10 @@ namespace Trickster.Bots
             var bossCards = state.legalCards.Where(c => IsCardHigh(c, knownCards));
             if (state.trumpSuit != Suit.Unknown)
             {
-                var lho = state.players.Single(p => p.Seat == (state.player.Seat + 1) % state.players.Count);
-                var rho = state.players.Single(p => p.Seat == (state.player.Seat - 1 + state.players.Count) % state.players.Count);
-
                 // Don't count off suit boss cards if opponents still have trump (excluding those who have already played to the trick)
+                // Also don't count off suit boss cards if the trick already contains trump
                 var players = new PlayersCollectionBase(this, state.players);
-                if (!players.LhoIsVoidInSuit(state.player, state.trumpSuit, knownCards) || (state.trick.Count == 0 && !players.RhoIsVoidInSuit(state.player, state.trumpSuit, knownCards)))
+                if (state.trick.Any(IsTrump) || !players.LhoIsVoidInSuit(state.player, state.trumpSuit, knownCards) || (state.trick.Count == 0 && !players.RhoIsVoidInSuit(state.player, state.trumpSuit, knownCards)))
                     bossCards = bossCards.Where(c => c.suit == state.trumpSuit);
             }
 
@@ -770,7 +768,7 @@ namespace Trickster.Bots
             Card coverHonor = null;
 
             // If we can trump in, do so
-            var legalTrump = state.legalCards.Where(c => EffectiveSuit(c) == state.trumpSuit).OrderBy(RankSort);
+            var legalTrump = state.legalCards.Where(c => EffectiveSuit(c) == state.trumpSuit).OrderBy(RankSort).ToList();
             if (ledCard.suit != state.trumpSuit && legalTrump.Any())
                 return legalTrump.First();
 
@@ -778,8 +776,9 @@ namespace Trickster.Bots
             // and it is the "setting trick" aka the trick to defeat the contract, take it.
             var tricksNeededToSet = GetTricksNeededToSet(state);
             var sureWinners = GetSureWinners(state);
-            if (sureWinners.Any() && sureWinners.Count() >= tricksNeededToSet)
-                return sureWinners.First();
+            var sureWinnersInSuit = sureWinners.Where(c => EffectiveSuit(c) == ledSuit).ToList();
+            if (sureWinnersInSuit.Any() && sureWinners.Count >= tricksNeededToSet)
+                return sureWinnersInSuit.First();
 
             var knownCards = state.legalCards.Concat(state.cardsPlayed);
             var isDummyRHO = GetNextSeatAfter(dummy.Seat, state.players.Count) == state.player.Seat;

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -359,7 +359,7 @@ namespace Trickster.Bots
 
             // Start with the min count we know from bidding
             if (summary.HandShape.ContainsKey(state.trumpSuit))
-                return nCardsInTrump = summary.HandShape[state.trumpSuit].Min;
+                nCardsInTrump = summary.HandShape[state.trumpSuit].Min;
 
             if (nCardsInTrump <= 0)
                 return 0;


### PR DESCRIPTION
Fix #129 

This happened because the bot knew LHO was void but failed to take into account trump had already been played to the trick. It also failed to take into account the led suit for the current trick (as a card would only win if it followed suit).

Fixed by excluding off-suits from sure tricks if the current trick contains trump AND only moving forward with sure tricks if at least one of the winners is in the led suit.