### PR TITLE
Bridge: Fix bids missing HandShape requirements

### DIFF
--- a/TestBots/Bridge/SAYC/2NT Responses.pbn
+++ b/TestBots/Bridge/SAYC/2NT Responses.pbn
@@ -1,0 +1,5 @@
+[Event "2NT Response - Pass"]
+[Deal "N:JT3.Q75.T8642.83 - - -"]
+[Auction "N"]
+Pass Pass 2NT Pass
+Pass Pass

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 12/3/2022 10:06 AM (-08:00)
+// last updated 8/14/2023 3:24 PM (-05:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -63,7 +63,7 @@ namespace TestBots
                 {
                     new SaycResult(false, 428),
                     new SaycResult(true, 432),
-                    new SaycResult(false, 430),
+                    new SaycResult(false, 431),
                     new SaycResult(false, 431)
                 }
              },
@@ -806,7 +806,7 @@ namespace TestBots
                     new SaycResult(true, 421),
                     new SaycResult(true, 432),
                     new SaycResult(true, 412),
-                    new SaycResult(false, 415),
+                    new SaycResult(false, 440),
                     new SaycResult(false, 429),
                     new SaycResult(true, 428),
                     new SaycResult(true, 439),

--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Bridge\TestBridgeBot.cs" />
     <Compile Include="Bridge\Test_Sayc.cs" />
     <Compile Include="Bridge\Test_Sayc_Results.cs" />
+    <Compile Include="TestFiveHundredBot.cs" />
     <Compile Include="TestHeartsBot.cs" />
     <Compile Include="TestOhHellBot.cs" />
     <Compile Include="TestPinochleBot.cs" />
@@ -91,6 +92,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Bridge\SAYC\Defensive Discards.pbn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Bridge\SAYC\2NT Responses.pbn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <None Include="packages.config" />

--- a/TricksterBots/Bots/Bridge/bridgebid/conventions/TakeoutDouble.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/conventions/TakeoutDouble.cs
@@ -132,7 +132,7 @@ namespace Trickster.Bots
                     //  12+ points: get the partnership to game
                     var minCards = BridgeBot.IsMajor(advance.declareBid.suit) ? 4 : 5;
                     advance.Points.Min = 12;
-                    advance.HandShape[advance.declareBid.suit].Min = 5;
+                    advance.HandShape[advance.declareBid.suit].Min = minCards;
                     advance.Description = $"{minCards}+ {advance.declareBid.suit}";
                 }
             }

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
@@ -152,6 +152,7 @@ namespace Trickster.Bots
                         //  1N-2S (overridden by Relay)
                         response.BidMessage = BidMessage.Signoff;
                         response.Points.Max = 7;
+                        response.HandShape[response.declareBid.suit].Min = 5;
                         response.Description = $"5+ {response.declareBid.suit}";
                     }
 
@@ -253,6 +254,7 @@ namespace Trickster.Bots
                         response.BidMessage = BidMessage.Forcing;
                         response.Points.Min = 4;
                         response.Points.Max = 10;
+                        response.HandShape[response.declareBid.suit].Min = 5;
                         response.Description = $"5+ {response.declareBid.suit}";
                     }
 
@@ -449,6 +451,7 @@ namespace Trickster.Bots
                             response.Points.Max = 15;
                             response.BidPointType = BidPointType.Hcp;
                             response.IsBalanced = true;
+                            response.HandShape[opening.declareBid.suit].Min = 2;
                             response.Description = $"2+ {opening.declareBid.suit}";
                             break;
                     }


### PR DESCRIPTION
Found via a challenge this past weekend where the bot made a bid indicating it had 5+ Spades when it only actually had 3.

When investigating, I found this occurred because even though "5+ Spades" was listed in the Description, no HandShape was actually set. Fixed by setting the HandShape.

I decided to search the code for similar bugs in other places and found a few more (which I also fixed). These resulted in a couple of changes to the results in the SAYC test suite which gave us some better bids (though still not the ideal ones in those two cases).