### PR TITLE
Bridge: Fix erroneous 4NT and 5NT bids

### DIFF
--- a/TestBots/Bridge/SAYC/Overcalls.pbn
+++ b/TestBots/Bridge/SAYC/Overcalls.pbn
@@ -1,0 +1,6 @@
+
+[Event "Avoid advancing an overcall without support"]
+[Deal "W:- J984.KJ5.8643.64 - -"]
+[Auction "W"]
+1H Pass 1S 2C
+3H Pass

--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -97,6 +97,9 @@
     <Content Include="Bridge\SAYC\2NT Responses.pbn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Bridge\SAYC\Overcalls.pbn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/Advance.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/Advance.cs
@@ -86,19 +86,21 @@ namespace Trickster.Bots
             else if (advance.declareBid.suit == Suit.Unknown)
             {
                 //  advancing in notrump, e.g. (1C)-1H-(P)-1N
-                advance.IsBalanced = true;
-                advance.Description = $"stopper in {opening.declareBid.suit}";
-                advance.Validate = hand => BasicBidding.HasStopper(hand, opening.declareBid.suit);
-
                 if (advance.declareBid.level == overcall.declareBid.level)
                 {
                     advance.Points.Min = 6;
                     advance.Points.Max = 10;
+                    advance.IsBalanced = true;
+                    advance.Description = $"stopper in {opening.declareBid.suit}";
+                    advance.Validate = hand => BasicBidding.HasStopper(hand, opening.declareBid.suit);
                 }
                 else if (advance.declareBid.level == overcall.declareBid.level + 1)
                 {
                     advance.Points.Min = 11;
                     advance.Points.Max = 12;
+                    advance.IsBalanced = true;
+                    advance.Description = $"stopper in {opening.declareBid.suit}";
+                    advance.Validate = hand => BasicBidding.HasStopper(hand, opening.declareBid.suit);
                 }
             }
             else


### PR DESCRIPTION
Fix #155

These were due to missing constraints on advancing an overcall which caused some values to be assigned to double and triple jumps in NT (which should have remained ignored).