### PR TITLE
Bridge: Fix unbounded cuebid when advancing

### DIFF
--- a/TestBots/Bridge/SAYC/Overcalls.pbn
+++ b/TestBots/Bridge/SAYC/Overcalls.pbn
@@ -4,3 +4,15 @@
 [Auction "W"]
 1H Pass 1S 2C
 3H Pass
+
+[Event "Allow cuebids when advancing at 1+ opener's level"]
+[Deal "E:J87632.QJ863.4.A - - -"]
+[Auction "E"]
+Pass 3D 3S Pass
+4D
+
+[Event "Avoid cuebids when advancing beyond 1+ opener's level"]
+[Deal "E:J87632.QJ863.4.A - - -"]
+[Auction "E"]
+Pass 3D 3S 5D
+Pass

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/Advance.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/Advance.cs
@@ -44,7 +44,7 @@ namespace Trickster.Bots
                 //  a cuebid advance when overcall was also a cuebid is unknown (for now)
                 //  TODO: Determine if there are conditions where this makes sense
             }
-            else if (opening.declareBid.suit == advance.declareBid.suit)
+            else if (opening.declareBid.suit == advance.declareBid.suit && advance.declareBid.level == opening.declareBid.level + 1)
             {
                 //  cuebid the oppenents' suit to show support with 10+ points
                 advance.BidConvention = BidConvention.Cuebid;


### PR DESCRIPTION
Fix #152

Now limits advancing to use a cuebid only at 1+ the opening level.