### PR TITLE
Fix rebidding 3NT as responder even if not balanced

### DIFF
--- a/TestBots/Bridge/SAYC/Responder Rebid.pbn
+++ b/TestBots/Bridge/SAYC/Responder Rebid.pbn
@@ -1,0 +1,7 @@
+
+[Event "Responder should rebid 3NT even if not balanced"]
+[Deal "S:- - JT653.A3.AKJT5.8 -"]
+[Auction "S"]
+1C Pass 1S Pass
+1NT Pass 3NT
+

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 8/14/2023 3:24 PM (-05:00)
+// last updated 9/6/2023 11:03 AM (-05:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -851,7 +851,7 @@ namespace TestBots
                     new SaycResult(false, 422),
                     new SaycResult(true, 420),
                     new SaycResult(true, -2),
-                    new SaycResult(false, -2),
+                    new SaycResult(true, 428),
                     new SaycResult(false, 421),
                     new SaycResult(false, 424),
                     new SaycResult(false, 424),

--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -100,6 +100,9 @@
     <Content Include="Bridge\SAYC\Overcalls.pbn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Bridge\SAYC\Responder Rebid.pbn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/ResponderRebid.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/ResponderRebid.cs
@@ -52,13 +52,12 @@ namespace Trickster.Bots
                 //  TODO: validate knowing count of Aces will help decision to bid slam
                 bid.Validate = hand => false;
             }
-            else if (bid.declareBid.level == bid.GameLevel && (isNT && partnerSummary.IsBalanced || playerMinOfSuit > 0 || partnerMinOfSuit > 0))
+            else if (bid.declareBid.level == bid.GameLevel && ((isNT && partnerSummary.IsBalanced) || playerMinOfSuit > 0 || partnerMinOfSuit > 0))
             {
                 //  sign-off at game of a previously bid suit: 3NT, 4H, 4S, 5C, 5D
                 bid.Points.Min = bid.GamePoints - partnerSummary.Points.Min;
                 bid.BidMessage = BidMessage.Signoff;
                 bid.Description = "Sign-off at game";
-                bid.IsBalanced = isNT;
             }
             else if (bid.declareBid.level == (isNT ? 2 : 3))
             {


### PR DESCRIPTION
Fix #165 

Per SAYC, a 3NT bid does not need to be balanced in responder's rebid.