### PR TITLE
Bridge: Stop passing when too strong

### DIFF
--- a/TestBots/Bridge/SAYC/Responder Rebid.pbn
+++ b/TestBots/Bridge/SAYC/Responder Rebid.pbn
@@ -5,3 +5,7 @@
 1C Pass 1S Pass
 1NT Pass 3NT
 
+[Event "Trickster Cards: Join Bridge"]
+[Deal "N:- - QJ8.K6.AQ8752.95 -"]
+[Auction "N"]
+1D Pass 3D

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 9/6/2023 11:03 AM (-05:00)
+// last updated 9/6/2023 12:02 PM (-05:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -276,22 +276,22 @@ namespace TestBots
                     new SaycResult(true, 416),
                     new SaycResult(true, -2),
                     new SaycResult(true, -2),
-                    new SaycResult(false, -2)
+                    new SaycResult(false, 429)
                 }
              },
              {
                 "test_invitational_response_to_one_of_a_minor", new[]
                 {
                     new SaycResult(true, 415),
-                    new SaycResult(false, -2),
+                    new SaycResult(false, 422),
                     new SaycResult(true, 414),
                     new SaycResult(true, 422),
                     new SaycResult(true, 429),
                     new SaycResult(true, 421),
                     new SaycResult(false, 416),
                     new SaycResult(false, 445),
-                    new SaycResult(false, -2),
-                    new SaycResult(false, -2)
+                    new SaycResult(true, 412),
+                    new SaycResult(false, 422)
                 }
              },
              {
@@ -305,10 +305,10 @@ namespace TestBots
                     new SaycResult(true, 416),
                     new SaycResult(true, 428),
                     new SaycResult(true, 428),
-                    new SaycResult(false, -2),
-                    new SaycResult(false, -2),
-                    new SaycResult(false, -2),
-                    new SaycResult(false, -2),
+                    new SaycResult(false, 422),
+                    new SaycResult(false, 429),
+                    new SaycResult(false, 430),
+                    new SaycResult(false, 429),
                     new SaycResult(false, 429),
                     new SaycResult(true, 421)
                 }
@@ -367,12 +367,12 @@ namespace TestBots
                     new SaycResult(false, 428),
                     new SaycResult(false, -2),
                     new SaycResult(false, 429),
-                    new SaycResult(false, 424),
-                    new SaycResult(false, 423),
+                    new SaycResult(false, 430),
+                    new SaycResult(false, 432),
                     new SaycResult(false, 440),
                     new SaycResult(false, -2),
                     new SaycResult(false, 420),
-                    new SaycResult(false, 423),
+                    new SaycResult(false, 429),
                     new SaycResult(false, 439)
                 }
              },
@@ -459,7 +459,7 @@ namespace TestBots
                     new SaycResult(false, 430),
                     new SaycResult(false, 424),
                     new SaycResult(false, -2),
-                    new SaycResult(false, 429),
+                    new SaycResult(false, 432),
                     new SaycResult(false, 423)
                 }
              },
@@ -853,7 +853,7 @@ namespace TestBots
                     new SaycResult(true, -2),
                     new SaycResult(true, 428),
                     new SaycResult(false, 421),
-                    new SaycResult(false, 424),
+                    new SaycResult(false, 420),
                     new SaycResult(false, 424),
                     new SaycResult(false, 412),
                     new SaycResult(false, 423),
@@ -969,7 +969,7 @@ namespace TestBots
                     new SaycResult(true, 428),
                     new SaycResult(false, -2),
                     new SaycResult(false, -2),
-                    new SaycResult(false, 422),
+                    new SaycResult(false, 429),
                     new SaycResult(false, 421),
                     new SaycResult(true, -2),
                     new SaycResult(true, 440),
@@ -1003,7 +1003,7 @@ namespace TestBots
                     new SaycResult(true, 415),
                     new SaycResult(true, 415),
                     new SaycResult(true, -2),
-                    new SaycResult(false, 432),
+                    new SaycResult(false, 438),
                     new SaycResult(false, 424),
                     new SaycResult(false, 415),
                     new SaycResult(true, 439),
@@ -1082,7 +1082,7 @@ namespace TestBots
                     new SaycResult(true, 412),
                     new SaycResult(false, -2),
                     new SaycResult(false, -2),
-                    new SaycResult(false, -2),
+                    new SaycResult(false, 431),
                     new SaycResult(false, -2),
                     new SaycResult(false, 423),
                     new SaycResult(false, -2),
@@ -1091,7 +1091,7 @@ namespace TestBots
                     new SaycResult(true, -2),
                     new SaycResult(false, 440),
                     new SaycResult(false, 430),
-                    new SaycResult(false, 429),
+                    new SaycResult(true, 432),
                     new SaycResult(true, -2),
                     new SaycResult(true, -2),
                     new SaycResult(false, -2),

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -64,11 +64,15 @@ namespace Trickster.Bots
             //  get and sort all possible suggestions
             var suggestions = legalBids.Where(b => b.why.Match(hand)).ToList();
 
-            //  if nothing matched, include bids we were too strong for
+            //  if nothing matched, include bids we were too strong for (preferring strongest bids)
             if (!suggestions.Any())
-                suggestions = legalBids.Where(b => b.why.Match(hand, allowTooStrong: true)).ToList();
-
-            if (legalBids[0].why.BidPhase == BidPhase.Opening)
+            {
+                suggestions = legalBids.Where(b => b.why.Match(hand, allowTooStrong: true))
+                    .OrderByDescending(s => s.why.Points.Max)
+                    .ThenByDescending(s => s.why.Priority)
+                    .ThenByDescending(s => s.why.HandShape.Max(hs => hs.Value.Min)).ToList();
+            }
+            else if (legalBids[0].why.BidPhase == BidPhase.Opening)
                 //  when opening, prefer suggestions with higher minimum points first, then higher minimum cards
             {
                 suggestions = suggestions

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -62,14 +62,19 @@ namespace Trickster.Bots
                 legalBid.why = new InterpretedBid(legalBid.value, interpretedHistory, interpretedHistory.Count);
 
             //  get and sort all possible suggestions
-            var suggestions = legalBids.Where(b => b.why.Match(hand));
+            var suggestions = legalBids.Where(b => b.why.Match(hand)).ToList();
+
+            //  if nothing matched, include bids we were too strong for
+            if (!suggestions.Any())
+                suggestions = legalBids.Where(b => b.why.Match(hand, allowTooStrong: true)).ToList();
+
             if (legalBids[0].why.BidPhase == BidPhase.Opening)
                 //  when opening, prefer suggestions with higher minimum points first, then higher minimum cards
             {
                 suggestions = suggestions
                     .OrderByDescending(s => s.why.Priority)
                     .ThenByDescending(s => s.why.Points.Min)
-                    .ThenByDescending(s => s.why.HandShape.Max(hs => hs.Value.Min));
+                    .ThenByDescending(s => s.why.HandShape.Max(hs => hs.Value.Min)).ToList();
             }
             else
                 //  in other phases, prefer finding the best fit first (prioritizing majors), then higher minimum points
@@ -78,7 +83,7 @@ namespace Trickster.Bots
                     .OrderByDescending(s => s.why.Priority)
                     .ThenBy(s => s.why.HandShape.Any(hs => IsMajor(hs.Key) && hs.Value.Min > 3) ? 0 : 1)
                     .ThenByDescending(s => s.why.HandShape.Max(hs => hs.Value.Min))
-                    .ThenByDescending(s => s.why.Points.Min);
+                    .ThenByDescending(s => s.why.Points.Min).ToList();
             }
 
             //  then favor the most "descriptive" one

--- a/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
@@ -186,7 +186,7 @@ namespace Trickster.Bots
             return 1;
         }
 
-        public bool Match(Hand hand)
+        public bool Match(Hand hand, bool allowTooStrong = false)
         {
             if (AlternateMatches != null && AlternateMatches(hand))
                 return true;
@@ -212,7 +212,7 @@ namespace Trickster.Bots
                     throw new Exception("Unknown point type");
             }
 
-            if (Points.Min > points || points > Points.Max)
+            if (Points.Min > points || (points > Points.Max && !allowTooStrong))
                 return false;
 
             var counts = BasicBidding.CountsBySuit(hand);


### PR DESCRIPTION
Fix #167

Previously if no bids matched because the hand was too strong for any of them (and didn't fit the shape of others) the bot would pass unless partner's bid was forcing.

This change uncaps bids when this situation is hit allowing the bot to make a bid it was otherwise too strong for (which is at least better than passing, if not always optimal).