### PR TITLE
500: Improve defense against Open Misere/Nullo

### DIFF
--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -138,7 +138,8 @@ namespace TestBots
         [TestMethod]
         [DataRow("7S",   "", "ADKDQD8C7C6CHJ7S", "JD9D8D6D8HJSTS5S", 3)] // Don't lead suit where misere bidder is void
         [DataRow("6C",   "",       "ADKD8C7C6C",       "JSTS9D8D6D", 3)] // Don't lead boss until no other choice (at which point we claim)
-        [DataRow("9C", "6C",           "9C5C9S",           "JSTS6D", 1)] // Follow high if we know misere bidder is void
+        [DataRow("9C", "6C",           "9C5C9S",           "JSTS6D", 1)] // Follow high if we know misere bidder is void in led suit
+        [DataRow("5C", "6C",           "9C5C9S",           "JCTC6D", 1)] // Follow low if misere bidder still has led suit
         public void SetOpenMisere(string expectedCard, string trick, string hand, string misereHand, int misereSeat)
         {
             var otherHandLength = trick.Length > 0 ? hand.Length / 2 - 1 : hand.Length / 2;

--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
 using Trickster.Bots;
 using Trickster.cloud;
 
@@ -114,7 +115,6 @@ namespace TestBots
             Assert.AreEqual("3D", $"{suggestion}");
         }
 
-
         [TestMethod]
         public void PlayUnderMisereIfPossibleWithJoker()
         {
@@ -133,6 +133,31 @@ namespace TestBots
             );
             var suggestion = bot.SuggestNextCard(cardState);
             Assert.AreEqual("KC", $"{suggestion}");
+        }
+
+        [TestMethod]
+        [DataRow("7S",   "", "ADKDQD8C7C6CHJ7S", "JD9D8D6D8HJSTS5S", 3)] // Don't lead suit where misere bidder is void
+        [DataRow("6C",   "",       "ADKD8C7C6C",       "JSTS9D8D6D", 3)] // Don't lead boss until no other choice (at which point we claim)
+        [DataRow("9C", "6C",           "9C5C9S",           "JSTS6D", 1)] // Follow high if we know misere bidder is void
+        public void SetOpenMisere(string expectedCard, string trick, string hand, string misereHand, int misereSeat)
+        {
+            var otherHandLength = trick.Length > 0 ? hand.Length / 2 - 1 : hand.Length / 2;
+            var misereBid = FiveHundredBid.OpenMisereBidByPoints[FiveHundredOpenNulloPoints.FiveHundred];
+            var players = new[]
+            {
+                new TestPlayer(FiveHundredBid.NotContractorBid, hand),
+                new TestPlayer(misereSeat == 1 ? misereBid : BidBase.NotPlaying, misereSeat == 1 ? misereHand : "0?0?0?0?0?0?0?0?0?0?"),
+                new TestPlayer(FiveHundredBid.NotContractorBid, string.Join("", Enumerable.Repeat("0?", otherHandLength))),
+                new TestPlayer(misereSeat == 3 ? misereBid : BidBase.NotPlaying, misereSeat == 3 ? misereHand : "0?0?0?0?0?0?0?0?0?0?"),
+            };
+            var bot = GetBot(Suit.Unknown, defaultOptions);
+            var cardState = new TestCardState<FiveHundredOptions>(
+                bot,
+                players,
+                trick: trick
+            );
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual(expectedCard, $"{suggestion}");
         }
 
         private static FiveHundredBot GetBot(Suit trumpSuit, FiveHundredOptions options)

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -49,7 +49,7 @@ namespace Trickster.Bots
 
         public virtual bool CanSeeHand(PlayersCollectionBase players, PlayerBase player, PlayerBase target)
         {
-            return player.Seat == target.Seat;
+            return player.Seat == target.Seat || (target.Hand.Length > 0 && new Hand(target.Hand).All(c => c.rank != Rank.Unknown && c.suit != Suit.Unknown));
         }
 
         public abstract DeckType DeckType { get; }

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -49,7 +49,15 @@ namespace Trickster.Bots
 
         public virtual bool CanSeeHand(PlayersCollectionBase players, PlayerBase player, PlayerBase target)
         {
-            return player.Seat == target.Seat || (target.Hand.Length > 0 && new Hand(target.Hand).All(c => c.rank != Rank.Unknown && c.suit != Suit.Unknown));
+            //  a player can always see their own cards
+            if (player.Seat == target.Seat)
+                return true;
+
+            //  a player can see the hand of any other player for which the caller sent all known cards
+            if (!string.IsNullOrEmpty(target.Hand) && new Hand(target.Hand).All(c => c.rank != Rank.Unknown && c.suit != Suit.Unknown))
+                return true;
+
+            return false;
         }
 
         public abstract DeckType DeckType { get; }

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -31,6 +31,11 @@ namespace Trickster.Bots
 
         private int KittySize => options.deckSize - 40;
 
+        public override bool CanSeeHand(PlayersCollectionBase players, PlayerBase player, PlayerBase target)
+        {
+            return player.Seat == target.Seat || (new FiveHundredBid(target.Bid).IsOpen && players.All(p => !p.IsActivelyPlaying || p.Hand.Length / 2 < 10));
+        }
+
         public override BidBase SuggestBid(SuggestBidState<FiveHundredOptions> state)
         {
             var (players, hand, legalBids, player) = (new PlayersCollectionBase(this, state.players), state.hand, state.legalBids, state.player);

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -31,11 +31,6 @@ namespace Trickster.Bots
 
         private int KittySize => options.deckSize - 40;
 
-        public override bool CanSeeHand(PlayersCollectionBase players, PlayerBase player, PlayerBase target)
-        {
-            return player.Seat == target.Seat || (new FiveHundredBid(target.Bid).IsOpen && players.All(p => !p.IsActivelyPlaying || p.Hand.Length / 2 < 10));
-        }
-
         public override BidBase SuggestBid(SuggestBidState<FiveHundredOptions> state)
         {
             var (players, hand, legalBids, player) = (new PlayersCollectionBase(this, state.players), state.hand, state.legalBids, state.player);

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -363,6 +363,12 @@ namespace Trickster.Bots
                     .Where(c => !avoidSuits.Contains(EffectiveSuit(c))) //  avoid leading a suit any nullo player is void in
                     .Where(c => !IsCardHigh(c, knownCards)) //  also avoid leading a card that is known to be high
                     .ToList();
+
+                //  fall back to avoiding cards known to be high, but allowing suits where nullo is void
+                //  (gives partner a chance to take the lead)
+                if (preferredLegalCards.Count == 0)
+                    preferredLegalCards = legalCards.Where(c => !IsCardHigh(c, knownCards)).ToList();
+
                 if (preferredLegalCards.Count > 0)
                     legalCards = preferredLegalCards;
 

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -359,18 +359,23 @@ namespace Trickster.Bots
 
                 foreach (var suit in SuitRank.stdSuits)
                 {
-                    //  avoid leading a suit any nullo player is void in
                     if (nulloPlayers.Any(p => players.TargetIsVoidInSuit(player, p, suit, cardsPlayed)))
                         avoidSuits.Add(suit);
                 }
 
-                var preferredLegalCards = legalCards.Where(c => !avoidSuits.Contains(EffectiveSuit(c))).ToList();
+                var knownCards = cardsPlayed.Concat(legalCards).ToList();
+                var preferredLegalCards = legalCards
+                    .Where(c => !avoidSuits.Contains(EffectiveSuit(c))) //  avoid leading a suit any nullo player is void in
+                    .Where(c => !IsCardHigh(c, knownCards)) //  also avoid leading a card that is known to be high
+                    .ToList();
+                if (preferredLegalCards.Count > 0)
+                    legalCards = preferredLegalCards;
 
-                return TryDumpEm(trick, preferredLegalCards.Count > 0 ? preferredLegalCards : legalCards, players.Count);
+                return TryDumpEm(trick, legalCards, players.Count);
             }
 
-            //  if we're not leading, but a nullo player has yet to play, play low
-            if (nulloPlayers.Any(p => p.Hand.Length == player.Hand.Length))
+            //  if we're not leading, but a nullo player has yet to play and isn't void in the led suit, play low
+            if (nulloPlayers.Any(p => p.Hand.Length == player.Hand.Length && !players.TargetIsVoidInSuit(player, p, trick[0], cardsPlayed)))
                 return TryDumpEm(trick, legalCards, players.Count);
 
             //  if a nullo player is taking the trick, try to get under them (but go high if we can't)


### PR DESCRIPTION
Fix #33 

Fixes the bot to incorporate the open misere bidder's hand when determining void suits, etc.