### PR TITLE
Bridge: Recognize Blackwood during an advance

### DIFF
--- a/TestBots/Bridge/SAYC/Blackwood.pbn
+++ b/TestBots/Bridge/SAYC/Blackwood.pbn
@@ -1,0 +1,8 @@
+
+[Event "Respond to Blackwood 4NT after preemptive overcall"]
+[Deal "W:- 87.8.KQJ7532.J84 - -"]
+[Declarer "N"]
+[Contract "4NT"]
+[Auction "W"]
+1H 3D Pass 4NT
+Pass 5C

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 9/6/2023 11:03 AM (-05:00)
+// last updated 9/20/2023 2:32 PM (-05:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -713,8 +713,8 @@ namespace TestBots
                     new SaycResult(false, -2),
                     new SaycResult(true, -2),
                     new SaycResult(false, -2),
-                    new SaycResult(false, -2),
-                    new SaycResult(false, -2),
+                    new SaycResult(true, 445),
+                    new SaycResult(false, 445),
                     new SaycResult(false, -2),
                     new SaycResult(false, 429)
                 }

--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -103,6 +103,9 @@
     <Content Include="Bridge\SAYC\Responder Rebid.pbn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Bridge\SAYC\Blackwood.pbn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/Advance.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/Advance.cs
@@ -85,8 +85,16 @@ namespace Trickster.Bots
             }
             else if (advance.declareBid.suit == Suit.Unknown)
             {
+                if (advance.declareBid.level == 4)
+                {
+                    advance.BidConvention = BidConvention.Blackwood;
+                    advance.BidMessage = BidMessage.Forcing;
+                    advance.Description = "asking for Aces";
+                    //  TODO: validate knowing count of Aces will help decision to bid slam
+                    advance.Validate = hand => false;
+                }
                 //  advancing in notrump, e.g. (1C)-1H-(P)-1N
-                if (advance.declareBid.level == overcall.declareBid.level)
+                else if (advance.declareBid.level == overcall.declareBid.level)
                 {
                     advance.Points.Min = 6;
                     advance.Points.Max = 10;


### PR DESCRIPTION
Fix #174

This case was simply missing from the logic. 