### PR TITLE
Bridge: Fallback to NT if no fit with partner

### DIFF
--- a/TestBots/Bridge/SAYC/Opener Rebid.pbn
+++ b/TestBots/Bridge/SAYC/Opener Rebid.pbn
@@ -1,0 +1,5 @@
+[Event "Opener should rebid 3NT, not 3C"]
+[Deal "E:AKQT72.AJ6.A72.6 - - -"]
+[Auction "E"]
+1S Pass 2C Pass
+3NT

--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -103,6 +103,9 @@
     <Content Include="Bridge\SAYC\Responder Rebid.pbn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Bridge\SAYC\Opener Rebid.pbn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -156,13 +156,7 @@ namespace Trickster.Bots
             var summary = new InterpretedBid.TeamSummary(history, history.Count - 2);
             var suit = summary.HandShape.Where(hs => hs.Value.Min >= 8).Select(hs => hs.Key).FirstOrDefault();
 
-            //  if we don't have a fit, go back to partner's best suit at the lowest available level
-            if (suit == Suit.Unknown)
-                suit = summary.p1.HandShape.Where(hs => hs.Value.Min > 0).OrderByDescending(hs => hs.Value.Min).Select(hs => hs.Key).FirstOrDefault();
-
-            //  if we don't know partner's suit, bid our best suit at the lowest available level
-            if (suit == Suit.Unknown)
-                suit = summary.p2.HandShape.Where(hs => hs.Value.Min > 0).OrderByDescending(hs => hs.Value.Min).Select(hs => hs.Key).FirstOrDefault();
+            //  if we don't have a fit, FirstOrDefault causes us to fall back to NT at the lowest available level
 
             return legalBids.FirstOrDefault(b => b.why.bidIsDeclare && b.why.declareBid.suit == suit);
         }


### PR DESCRIPTION
Fix #181 

This adjusts the case where no bid quite matches to fall back to NT if we don't have a fit with partner.

May still need some additional logic to rebid the original suit if sufficient length but too strong.