### PR TITLE
Pitch: Fix overbidding when holding the off-Jack

### DIFF
--- a/TestBots/TestPitchBot.cs
+++ b/TestBots/TestPitchBot.cs
@@ -40,16 +40,20 @@ namespace TestBots
         };
 
         [TestMethod]
-        [DataRow("ACKC3S6H7HQH",  3, false)]
-        [DataRow("7D5S8SQSAS6H",  3, false)]
-        [DataRow("ACKCQCJC2CAH",  4, false)]
-        [DataRow("6C5C5S4S3D2D",  0, false)]
-        [DataRow("ACKCQCJC2CAH", 15,  true)]
-        public void TestBids(string handString, int expectedBid, bool offerShoot)
+        [DataRow("ACKC3S6H7HQH",  3, false, PitchVariation.FourPoint)]
+        [DataRow("7D5S8SQSAS6H",  3, false, PitchVariation.FourPoint)]
+        [DataRow("ACKCQCJC2CAH",  4, false, PitchVariation.FourPoint)]
+        [DataRow("6C5C5S4S3D2D",  0, false, PitchVariation.FourPoint)]
+        [DataRow("ACKCQCJC2CAH", 15,  true, PitchVariation.FourPoint)]
+        [DataRow("KCQCJCJS3C2C",  8, false, PitchVariation.TenPoint )]
+        [DataRow("JCJSHJLJTC2C",  6, false, PitchVariation.TenPoint )]
+        [DataRow("JCJS5C4C3C2C",  6, false, PitchVariation.TenPoint )]
+        public void TestBids(string handString, int expectedBid, bool offerShoot, PitchVariation variation)
         {
-            var options = new PitchOptions
+            var isTenPoint = variation == PitchVariation.TenPoint;
+            var options = isTenPoint ? tenPointOptions : new PitchOptions
             {
-                variation = PitchVariation.FourPoint,
+                variation = variation,
                 drawOption = PitchDrawOption.NonTrump,
                 gameOverScore = 15,
                 isPartnership = true,
@@ -67,7 +71,9 @@ namespace TestBots
             if (expectedBid == 15)
                 bid = (int)PitchBid.ShootMoonBid;
 
-            Assert.AreEqual(bid, GetSuggestedBid(handString, out var hand, options), $"Expect bid of {expectedBid} for hand {Util.PrettyHand(hand)}");
+            var suggestion = GetSuggestedBid(handString, out var hand, options);
+            var suggestionValue = suggestion >= (int)PitchBid.Base ? suggestion - (int)PitchBid.Base : suggestion;
+            Assert.AreEqual(bid, suggestion, $"Expect bid of {expectedBid} for hand {Util.PrettyHand(hand)}, but got {suggestionValue}");
         }
 
         [TestMethod]
@@ -113,7 +119,7 @@ namespace TestBots
             };
 
             var bot = new PitchBot(GetCallForBestOptions(callPartnerSeat: 0), Suit.Hearts);
-            var cardState = new TestCardState<PitchOptions>(bot, players, "");
+            var cardState = new TestCardState<PitchOptions>(bot, players);
             var suggestion = bot.SuggestNextCard(cardState);
 
             Assert.AreEqual(card, $"{suggestion}");

--- a/TricksterBots/Bots/Pitch/PitchBot.cs
+++ b/TricksterBots/Bots/Pitch/PitchBot.cs
@@ -540,7 +540,7 @@ namespace Trickster.Bots
             //  take inventory of the relevant cards in our hand
             var trumpInHand = Math.Min(6, hand.Count(c => EffectiveSuit(c, t) == t));
             var ace = hand.Any(c => c.rank == Rank.Ace && c.suit == t);
-            var offace = hand.Any(c => c.rank == Rank.Jack && c.suit != t && EffectiveSuit(c, t) == t);
+            var offace = hand.Any(c => c.rank == Rank.Ace && c.suit != t && EffectiveSuit(c, t) == t);
             var king = hand.Any(c => c.rank == Rank.King && c.suit == t);
             var queen = hand.Any(c => c.rank == Rank.Queen && c.suit == t);
             var jack = hand.Any(c => c.rank == Rank.Jack && c.suit == t);


### PR DESCRIPTION
Fix #149

This is an old copy/paste error from when support for the accounting for the off-Ace during bidding (for 11-Point Pitch) was originally added to the bot.

Instead of checking for the off-Ace, the logic incorrectly checked for the off-Jack, causing holding the off-Jack to artificially inflate the estimated points held and points that could be captured (turning 6 bids into 8 bids, etc.)