### PR TITLE
500: Bid only as high as needed to win the game

### DIFF
--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -28,6 +28,7 @@ namespace TestBots
         [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480,     "", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Keep bidding if opponents might overbid but no higher than necessary")]
         [DataRow("Pass", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480,     "", "7D", "Pass", BidAfterPass.Always, DisplayName = "Don't bid higher than partner if we can reenter bidding")]
         [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480, "Pass", "7D",   "7H",  BidAfterPass.Never, DisplayName = "Overbid opponents but no higher than necessary")]
+        [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480, "Pass", "7D",   "7H", BidAfterPass.Always, DisplayName = "Overbid opponents even if we can reenter bidding")]
         public void TestBiddingNearGameOver(string bid, string hand, FiveHundredVariation variation, int score, string lhoBidStr, string partnerBidStr, string rhoBidStr, BidAfterPass bidAfterPass)
         {
             var lhoBid = new FiveHundredBid(GetBid(lhoBidStr));

--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -24,6 +24,7 @@ namespace TestBots
         [TestMethod]
         [DataRow( "10♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian,   0, "Pass", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Bid high with a good fit with partner")]
         [DataRow("Pass", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480, "Pass", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Don't bid higher than needed to win")]
+        [DataRow(  "9♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 120, "Pass", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Bid just high enough to win the game")]
         [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480,     "", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Keep bidding if opponents might overbid but no higher than necessary")]
         [DataRow("Pass", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480,     "", "7D", "Pass", BidAfterPass.Always, DisplayName = "Don't bid higher than partner if we can reenter bidding")]
         [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480, "Pass", "7D",   "7H",  BidAfterPass.Never, DisplayName = "Overbid opponents but no higher than necessary")]

--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Trickster.Bots;
 using Trickster.cloud;
 
@@ -18,6 +20,48 @@ namespace TestBots
             isPartnership = false,
             players = 3
         };
+
+        [TestMethod]
+        [DataRow( "10♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian,   0, "Pass", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Bid high with a good fit with partner")]
+        [DataRow("Pass", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480, "Pass", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Don't bid higher than needed to win")]
+        [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480,     "", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Keep bidding if opponents might overbid but no higher than necessary")]
+        [DataRow("Pass", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480,     "", "7D", "Pass", BidAfterPass.Always, DisplayName = "Don't bid higher than partner if we can reenter bidding")]
+        [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480, "Pass", "7D",   "7H",  BidAfterPass.Never, DisplayName = "Overbid opponents but no higher than necessary")]
+        public void TestBiddingNearGameOver(string bid, string hand, FiveHundredVariation variation, int score, string lhoBidStr, string partnerBidStr, string rhoBidStr, BidAfterPass bidAfterPass)
+        {
+            var lhoBid = new FiveHundredBid(GetBid(lhoBidStr));
+            var partnerBid = new FiveHundredBid(GetBid(partnerBidStr));
+            var rhoBid = new FiveHundredBid(GetBid(rhoBidStr));
+            var options = new FiveHundredOptions
+            {
+                bidAfterPass = bidAfterPass,
+                variation = variation,
+                whenNullo = FiveHundredWhenNullo.Off,
+            };
+            var players = new[]
+            {
+                new TestPlayer(hand: hand, seat: 0, bid: new FiveHundredBid(Suit.Unknown, 6), gameScore: score),
+                new TestPlayer(hand: "0U0U0U0U0U0U0U0U0U0U", seat: 1, bid: lhoBid),
+                new TestPlayer(hand: "0U0U0U0U0U0U0U0U0U0U", seat: 2, bid: partnerBid, gameScore: score),
+                new TestPlayer(hand: "0U0U0U0U0U0U0U0U0U0U", seat: 3, bid: rhoBid)
+            };
+            
+            foreach (var p in players.Where(p => p.Bid != BidBase.NoBid))
+                p.BidHistory.Add(p.Bid);
+
+            var bot = GetBot(Suit.Unknown, options);
+            var bidState = new SuggestBidState<FiveHundredOptions>
+            {
+                dealerSeat = 3,
+                hand = new Hand(players[0].Hand),
+                legalBids = GetLegalBids(variation, partnerBid.IsContractor ? partnerBid.Tricks + 1 : 6),
+                options = options,
+                player = players[0],
+                players = players
+            };
+            var suggestion = bot.SuggestBid(bidState);
+            Assert.AreEqual(bid, suggestion.value == BidBase.Pass ? "Pass" : new FiveHundredBid(suggestion.value).ToString());
+        }
 
         [TestMethod]
         [DataRow("Pass", "HJ5S4S5H4H5D4D6C5C4C", FiveHundredVariation.Australian,         null, DisplayName = "Don't bid 6NT with Joker and a weak hand in Australian")]
@@ -199,6 +243,24 @@ namespace TestBots
             );
             var suggestion = bot.SuggestNextCard(cardState);
             Assert.AreEqual(expectedCard, $"{suggestion}");
+        }
+
+        private static int GetBid(string bid)
+        {
+            if (string.IsNullOrEmpty(bid))
+                return BidBase.NoBid;
+
+            if (bid == "Pass")
+                return BidBase.Pass;
+
+            var level = int.Parse(Regex.Match(bid, @"\d+").Value);
+            var suitString = Regex.Match(bid, @"\D+").Value;
+            var suitNames = Enum.GetNames(typeof(Suit));
+            var suitValues = Enum.GetValues(typeof(Suit));
+            var suitIndex = Array.FindIndex(suitNames, n => n.StartsWith(suitString));
+            var suit = suitIndex == -1 ? Suit.Unknown : (Suit)suitValues.GetValue(suitIndex);
+
+            return new FiveHundredBid(suit, level);
         }
 
         private static FiveHundredBot GetBot(Suit trumpSuit, FiveHundredOptions options)

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -117,7 +117,7 @@ namespace Trickster.Bots
                 var canReenterBidding = options.bidAfterPass != BidAfterPass.Never;
                 var opponentsHavePassed = players.Opponents(player).All(p => p.Bid == BidBase.Pass);
 
-                //  pass if our team has the high bid and opponents have all passed or we'll get the chance to bid again
+                //  pass if our team has the high bid, it's past the game over score, and opponents have all passed or we'll get the chance to bid again
                 if (teamHasHighBid && highBidIsPastGameOver && (opponentsHavePassed || canReenterBidding))
                     return new BidBase(BidBase.Pass);
 

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -107,13 +107,13 @@ namespace Trickster.Bots
             var suggestion = shouldSignal && bestFHB != null ? matches.FirstOrDefault(b => new FiveHundredBid(b.value).Suit == bestFHB.Suit) : best;
 
             //  only bid as high as necessary to win the game
-            var highBid = players.Select(p => new FiveHundredBid(p.Bid)).OrderByDescending(b => b).First();
-            var highBidIsPastGameOver = BidValue(highBid) + player.GameScore >= options.gameOverScore;
             var suggestionIsPastGameOver = suggestion != null && BidValue(new FiveHundredBid(suggestion.value)) + player.GameScore >= options.gameOverScore;
-            if (suggestion != null && (highBidIsPastGameOver || suggestionIsPastGameOver))
+            if (suggestion != null && suggestionIsPastGameOver)
             {
                 var partners = players.PartnersOf(player);
-                var teamHasHighBid = players.Any(p => p.Seat == player.Seat || partners.Any(partner => p.Seat == partner.Seat));
+                var highBid = players.Select(p => new FiveHundredBid(p.Bid)).OrderByDescending(b => b).First();
+                var highBidIsPastGameOver = BidValue(highBid) + player.GameScore >= options.gameOverScore;
+                var teamHasHighBid = players.Any(p => p.Bid == highBid && (p.Seat == player.Seat || partners.Any(partner => p.Seat == partner.Seat)));
                 var canReenterBidding = options.bidAfterPass != BidAfterPass.Never;
                 var opponentsHavePassed = players.Opponents(player).All(p => p.Bid == BidBase.Pass);
 

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -106,6 +106,30 @@ namespace Trickster.Bots
             var shouldSignal = options.variation == FiveHundredVariation.Australian && players.PartnersOf(player).Any(p => p.Bid != BidBase.Pass) && player.BidHistory.Count == 0;
             var suggestion = shouldSignal && bestFHB != null ? matches.FirstOrDefault(b => new FiveHundredBid(b.value).Suit == bestFHB.Suit) : best;
 
+            //  only bid as high as necessary to win the game
+            var highBid = players.Select(p => new FiveHundredBid(p.Bid)).OrderByDescending(b => b).First();
+            if (suggestion != null && BidValue(highBid) + player.GameScore >= options.gameOverScore)
+            {
+                var partners = players.PartnersOf(player);
+                var teamHasHighBid = players.Any(p => p.Seat == player.Seat || partners.Any(partner => p.Seat == partner.Seat));
+                var canReenterBidding = options.bidAfterPass != BidAfterPass.Never;
+                var opponentsHavePassed = players.Opponents(player).All(p => p.Bid == BidBase.Pass);
+
+                //  pass if our team has the high bid and opponents have all passed or we'll get the chance to bid again
+                if (teamHasHighBid && (opponentsHavePassed || canReenterBidding))
+                    return new BidBase(BidBase.Pass);
+
+                //  otherwise bid, but only as high as needed to win the game
+                suggestion = matches.FirstOrDefault(b =>
+                {
+                    var fhb = new FiveHundredBid(b.value);
+                    if (fhb.Suit != bestFHB.Suit)
+                        return false;
+
+                    return BidValue(fhb) + player.GameScore >= options.gameOverScore;
+                });
+            }
+
             return suggestion ?? new BidBase(BidBase.Pass);
         }
 
@@ -360,6 +384,15 @@ namespace Trickster.Bots
             //  active nullo players are those that either bid nullo (can be multiple if playing solo)
             //  OR partners of nullo bidders who are still in the game (will be face-up dummy hands played by the nullo bidder)
             return player.Bid == BidBase.Dummy || new FiveHundredBid(player.Bid).IsLikeNullo;
+        }
+
+        private int BidValue(FiveHundredBid theBid)
+        {
+            if (theBid.IsLikeNullo)
+                return theBid.IsOpen ? options.OpenNulloPoints : options.NulloPoints;
+
+            //  Avondale scoring from https://en.wikipedia.org/wiki/500_(card_game)
+            return 20 + FiveHundredBid.suitRank[theBid.Suit] * 20 + (theBid.Tricks - 6) * 100;
         }
 
         private Card TryBustNullo(PlayerBase player, IReadOnlyList<Card> trick, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, PlayersCollectionBase players, PlayerBase trickTaker)

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -108,7 +108,9 @@ namespace Trickster.Bots
 
             //  only bid as high as necessary to win the game
             var highBid = players.Select(p => new FiveHundredBid(p.Bid)).OrderByDescending(b => b).First();
-            if (suggestion != null && BidValue(highBid) + player.GameScore >= options.gameOverScore)
+            var highBidIsPastGameOver = BidValue(highBid) + player.GameScore >= options.gameOverScore;
+            var suggestionIsPastGameOver = suggestion != null && BidValue(new FiveHundredBid(suggestion.value)) + player.GameScore >= options.gameOverScore;
+            if (suggestion != null && (highBidIsPastGameOver || suggestionIsPastGameOver))
             {
                 var partners = players.PartnersOf(player);
                 var teamHasHighBid = players.Any(p => p.Seat == player.Seat || partners.Any(partner => p.Seat == partner.Seat));
@@ -116,7 +118,7 @@ namespace Trickster.Bots
                 var opponentsHavePassed = players.Opponents(player).All(p => p.Bid == BidBase.Pass);
 
                 //  pass if our team has the high bid and opponents have all passed or we'll get the chance to bid again
-                if (teamHasHighBid && (opponentsHavePassed || canReenterBidding))
+                if (teamHasHighBid && highBidIsPastGameOver && (opponentsHavePassed || canReenterBidding))
                     return new BidBase(BidBase.Pass);
 
                 //  otherwise bid, but only as high as needed to win the game

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -390,6 +390,9 @@ namespace Trickster.Bots
 
         private int BidValue(FiveHundredBid theBid)
         {
+            if (!theBid.IsContractor)
+                return 0;
+
             if (theBid.IsLikeNullo)
                 return theBid.IsOpen ? options.OpenNulloPoints : options.NulloPoints;
 


### PR DESCRIPTION
Fix #154

This take into account whether the bot's team is currently winning the bid, whether the opponents may still overbid, and whether we'll be able to bid again if the opponents do overbid.

The bot will stop bidding once the value of the bid is sufficiently high to win the game, but will keep raising the opponents if they compete up until the original bid the bot would have made.