### PR TITLE
500: Fix overbidding (especially in NT)

### DIFF
--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -109,6 +109,31 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void TrumpBossEvenIfLhoIsVoid()
+        {
+            var options = new FiveHundredOptions
+            {
+                deckSize = 46,
+                variation = FiveHundredVariation.American,
+            };
+            var players = new[]
+            {
+                new TestPlayer(new FiveHundredBid(GetBid("7NT")),   "HJKSQSTSJH9HKC"),
+                new TestPlayer(FiveHundredBid.NotContractorBid,     "0?0?0?0?0?0?0?", cardsTaken: "ADLJKD9D") { VoidSuits = new List<Suit> { Suit.Diamonds }},
+                new TestPlayer(FiveHundredBid.ContractorPartnerBid, "0?0?0?0?0?0?0?"),
+                new TestPlayer(FiveHundredBid.NotContractorBid,     "0?0?0?0?0?0?", cardsTaken: "ACJC6C4C"),
+            };
+            var bot = GetBot(Suit.Unknown, options);
+            var cardState = new TestCardState<FiveHundredOptions>(
+                bot,
+                players,
+                trick: "QD"
+            );
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("HJ", $"{suggestion}");
+        }
+
+        [TestMethod]
         public void SoloDucksIfEffectivePartnerTakingTrick()
         {
             var players = new[]

--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -22,14 +22,16 @@ namespace TestBots
         };
 
         [TestMethod]
-        [DataRow( "10♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian,   0, "Pass", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Bid high with a good fit with partner")]
-        [DataRow("Pass", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480, "Pass", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Don't bid higher than needed to win")]
-        [DataRow(  "9♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 120, "Pass", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Bid just high enough to win the game")]
-        [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480,     "", "7D", "Pass",  BidAfterPass.Never, DisplayName = "Keep bidding if opponents might overbid but no higher than necessary")]
-        [DataRow("Pass", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480,     "", "7D", "Pass", BidAfterPass.Always, DisplayName = "Don't bid higher than partner if we can reenter bidding")]
-        [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480, "Pass", "7D",   "7H",  BidAfterPass.Never, DisplayName = "Overbid opponents but no higher than necessary")]
-        [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 480, "Pass", "7D",   "7H", BidAfterPass.Always, DisplayName = "Overbid opponents even if we can reenter bidding")]
-        public void TestBiddingNearGameOver(string bid, string hand, FiveHundredVariation variation, int score, string lhoBidStr, string partnerBidStr, string rhoBidStr, BidAfterPass bidAfterPass)
+        [DataRow( "10♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 3,   0, "Pass",   "7D", "Pass",  BidAfterPass.Never, DisplayName = "Bid high with a good fit with partner")]
+        [DataRow("Pass", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 3, 480, "Pass",   "7D", "Pass",  BidAfterPass.Never, DisplayName = "Don't bid higher than needed to win")]
+        [DataRow(  "9♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 3, 120, "Pass",   "7D", "Pass",  BidAfterPass.Never, DisplayName = "Bid just high enough to win the game")]
+        [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 3, 480,     "",   "7D", "Pass",  BidAfterPass.Never, DisplayName = "Keep bidding if opponents might overbid but no higher than necessary")]
+        [DataRow("Pass", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 3, 480,     "",   "7D", "Pass", BidAfterPass.Always, DisplayName = "Don't bid higher than partner if we can reenter bidding")]
+        [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 3, 480, "Pass",   "7D",   "7H",  BidAfterPass.Never, DisplayName = "Overbid opponents but no higher than necessary")]
+        [DataRow(  "8♦", "HJASJS7SQHKDQD9D7D4D", FiveHundredVariation.Australian, 3, 480, "Pass",   "7D",   "7H", BidAfterPass.Always, DisplayName = "Overbid opponents even if we can reenter bidding")]
+        [DataRow("Pass", "HJKSJSTS6H5HKC7CKDQD",   FiveHundredVariation.American, 5,   0,     "", "Pass",   "8H",  BidAfterPass.Never, DisplayName = "Pass with insufficient strength to overbid opponents")]
+        [DataRow( "7NT", "HJQSKH6HQC5C4CQD7D6D",   FiveHundredVariation.American, 5,   0,     "",     "",     "",  BidAfterPass.Never, DisplayName = "Only count the Joker as stopper once in NT")]
+        public void TestBidding(string bid, string hand, FiveHundredVariation variation, int kittySize, int score, string lhoBidStr, string partnerBidStr, string rhoBidStr, BidAfterPass bidAfterPass)
         {
             var lhoBid = new FiveHundredBid(GetBid(lhoBidStr));
             var partnerBid = new FiveHundredBid(GetBid(partnerBidStr));
@@ -37,6 +39,7 @@ namespace TestBots
             var options = new FiveHundredOptions
             {
                 bidAfterPass = bidAfterPass,
+                deckSize = 40 + kittySize,
                 variation = variation,
                 whenNullo = FiveHundredWhenNullo.Off,
             };
@@ -56,7 +59,7 @@ namespace TestBots
             {
                 dealerSeat = 3,
                 hand = new Hand(players[0].Hand),
-                legalBids = GetLegalBids(variation, partnerBid.IsContractor ? partnerBid.Tricks + 1 : 6),
+                legalBids = GetLegalBids(variation, rhoBid.IsContractor ? rhoBid : partnerBid.IsContractor ? partnerBid : lhoBid.IsContractor ? lhoBid : new FiveHundredBid(BidBase.NoBid)),
                 options = options,
                 player = players[0],
                 players = players
@@ -67,10 +70,11 @@ namespace TestBots
 
         [TestMethod]
         [DataRow("Pass", "HJ5S4S5H4H5D4D6C5C4C", FiveHundredVariation.Australian,         null, DisplayName = "Don't bid 6NT with Joker and a weak hand in Australian")]
-        [DataRow("Pass", "HJAS4S5H4H5D4D6C5C4C", FiveHundredVariation.Australian,         null, DisplayName = "Bid 6NT with Joker and a near weak hand in Australian")]
+        [DataRow( "6NT", "HJAS4S5H4HKD4D6C5C4C", FiveHundredVariation.Australian,         null, DisplayName = "Bid 6NT with Joker and a near weak hand in Australian")]
         [DataRow( "6NT", "HJASKSAH4H5D4D6C5C4C", FiveHundredVariation.Australian,         null, DisplayName = "Bid 6NT with Joker and a medium hand in Australian")]
         [DataRow( "iNT", "HJ5S4S5H4H5D4D6C5C4C", FiveHundredVariation.American,           null, DisplayName = "Bid iNT in American")]
         [DataRow( "6NT", "HJJSJCASKSQSTS9S8S7S", FiveHundredVariation.Australian,         null, DisplayName = "Bid 6NT with Joker and a strong hand in Australian")]
+        [DataRow("10NT", "HJJSJCASKSQSTS9S8S7S", FiveHundredVariation.American,   Suit.Unknown, DisplayName = "Bid 10NT with Joker and a strong hand in Americat")]
         [DataRow("Pass", "ASKSQSAHKHQHACKCADKD", FiveHundredVariation.Australian,         null, DisplayName = "Don't bid any NT without Joker in Australian (if partner hasn't bid)")]
         [DataRow("Pass", "ASKSQSAHKHQHACKCADKD", FiveHundredVariation.Australian,  Suit.Spades, DisplayName = "Don't bid any NT without Joker in Australian (if partner didn't bid NT)")]
         [DataRow( "7NT", "ASKSQSAHKHQHACKCADKD", FiveHundredVariation.Australian, Suit.Unknown, DisplayName = "Bid 7NT without Joker if strong in NT and partner bid 6NT")]
@@ -270,7 +274,20 @@ namespace TestBots
             return new FiveHundredBot(options, trumpSuit);
         }
 
-        private static List<BidBase> GetLegalBids(FiveHundredVariation variation, int start = FiveHundredBid.MinTricks)
+        private static List<BidBase> GetLegalBids(FiveHundredVariation variation, FiveHundredBid afterBid)
+        {
+            if ((int)afterBid == BidBase.NoBid)
+                return GetLegalBids(variation);
+
+            if (afterBid.Suit == Suit.Unknown)
+                return GetLegalBids(variation, afterBid.Tricks + 1);
+
+            var nextSuitRank = FiveHundredBid.suitRank[afterBid.Suit] + 1;
+            var nextSuit = FiveHundredBid.suitRank.FirstOrDefault(sr => sr.Value == nextSuitRank).Key;
+            return GetLegalBids(variation, afterBid.Tricks, nextSuit);
+        }
+
+        private static List<BidBase> GetLegalBids(FiveHundredVariation variation, int start = FiveHundredBid.MinTricks, Suit startSuit = Suit.Spades)
         {
             var bids = new List<BidBase>();
 
@@ -278,6 +295,7 @@ namespace TestBots
             {
                 var inkle = variation == FiveHundredVariation.American && nTricks == FiveHundredBid.MinTricks;
                 bids.AddRange(FiveHundredBid.suitRank.OrderBy(sr => sr.Value)
+                    .Where(sr => nTricks > start || sr.Value >= FiveHundredBid.suitRank[startSuit])
                     .Select(sr => new BidBase(new FiveHundredBid(sr.Key, nTricks, inkle))));
             }
 

--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -70,7 +70,7 @@ namespace TestBots
 
         [TestMethod]
         [DataRow("Pass", "HJ5S4S5H4H5D4D6C5C4C", FiveHundredVariation.Australian,         null, DisplayName = "Don't bid 6NT with Joker and a weak hand in Australian")]
-        [DataRow( "6NT", "HJAS4S5H4HKD4D6C5C4C", FiveHundredVariation.Australian,         null, DisplayName = "Bid 6NT with Joker and a near weak hand in Australian")]
+        [DataRow( "6NT", "HJAS4S5H4HKD4DKC5C4C", FiveHundredVariation.Australian,         null, DisplayName = "Bid 6NT with Joker and a near weak hand in Australian")]
         [DataRow( "6NT", "HJASKSAH4H5D4D6C5C4C", FiveHundredVariation.Australian,         null, DisplayName = "Bid 6NT with Joker and a medium hand in Australian")]
         [DataRow( "iNT", "HJ5S4S5H4H5D4D6C5C4C", FiveHundredVariation.American,           null, DisplayName = "Bid iNT in American")]
         [DataRow( "6NT", "HJJSJCASKSQSTS9S8S7S", FiveHundredVariation.Australian,         null, DisplayName = "Bid 6NT with Joker and a strong hand in Australian")]

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -387,9 +387,9 @@ namespace Trickster.Bots
                 {
                     //  we can't follow suit but we have trump
 
-                    if (IsPartnership && trickCount == 1 && players.LhoIsVoidInSuit(player, firstCardInTrick, cardsPlayed))
+                    if (IsPartnership && trickCount == 1 && players.LhoIsVoidInSuit(player, firstCardInTrick, cardsPlayed) && !IsCardHigh(cardTakingTrick, cardsPlayed))
                     {
-                        //  second to play and left hand opponent is void in the led suit - don't trump-in; leave it to our partner
+                        //  second to play and left hand opponent is void in the led suit - don't trump-in; leave it to our partner unless led card is boss
                     }
                     else if (isPartnerTakingTrick && (lastToPlay || IsCardHigh(cardTakingTrick, cardsPlayed.Concat(new Hand(player.Hand)))))
                     {

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -346,7 +346,7 @@ namespace Trickster.Bots
 
                 var highRank = RankSort(deck.Last(), trumpSuit);
                 var nextHighestRank = highRank;
-                var hasStopper = nJokers > 0;
+                var hasStopper = nJokers > 0; //  if we have a Joker, we have a stopper for every suit
 
                 while (cards.Any())
                 {

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -346,7 +346,7 @@ namespace Trickster.Bots
 
                 var highRank = RankSort(deck.Last(), trumpSuit);
                 var nextHighestRank = highRank;
-                var hasStopper = false;
+                var hasStopper = nJokers > 0;
 
                 while (cards.Any())
                 {
@@ -371,7 +371,7 @@ namespace Trickster.Bots
                 }
 
                 //  if we're looking at no-trump and we don't have a stopper in all suits, bail
-                if (trumpSuit == Suit.Unknown && !hasStopper && nJokers == 0)
+                if (trumpSuit == Suit.Unknown && !hasStopper)
                     return 0;
             }
 

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -38,7 +38,7 @@ namespace Trickster.Bots
             var partnersBids = players.PartnersOf(player).Select(p => new FiveHundredBid(p.Bid)).ToList();
             var playerLastBid = player.BidHistory.Any() ? new FiveHundredBid(player.BidHistory.Last()) : new FiveHundredBid(BidBase.NoBid);
             var defaultPartnerTricks = players.Count == 3 ? 1 : 2;
-            var estimatedKittyTricks = KittySize > 3 ? 1 : 0;
+            var estimatedKittyTricks = 1;
             var minimumToBid6NT = 6 - defaultPartnerTricks - estimatedKittyTricks;
 
             //  calculate the raw number of tricks we can take with a given trump suit
@@ -339,7 +339,6 @@ namespace Trickster.Bots
             }
 
             //  then calculate the winners for each suit, accounting for gaps
-            var remainingJokers = nJokers;
             foreach (var suit in SuitRank.stdSuits)
             {
                 var deck = deckBySuit[suit];
@@ -361,29 +360,18 @@ namespace Trickster.Bots
                     var gaps = deck.Count(c => targetRank < RankSort(c, trumpSuit) && RankSort(c, trumpSuit) <= nextHighestRank && !cards.Contains(c));
                     var below = cards.Count(c => RankSort(c, trumpSuit) < targetRank);
 
-                    var usingJokerAsStopper = false;
                     if (gaps > below)
-                    {
-                        //  Jokers can be a stopper for any suit in NT (but can only be used to stop once)
-                        if (trumpSuit == Suit.Unknown && remainingJokers > 0 && gaps - 1 <= below)
-                        {
-                            usingJokerAsStopper = true;
-                            remainingJokers--;
-                        }
-                        else
-                            break;
-                    }
+                        break;
 
                     tricks++;
                     hasStopper = true;
                     nextHighestRank = targetRank - 1;
                     cards.Remove(targetCard);
-                    if (!usingJokerAsStopper)
-                        cards.RemoveRange(0, gaps);
+                    cards.RemoveRange(0, gaps);
                 }
 
                 //  if we're looking at no-trump and we don't have a stopper in all suits, bail
-                if (trumpSuit == Suit.Unknown && !hasStopper && remainingJokers <= 0)
+                if (trumpSuit == Suit.Unknown && !hasStopper && nJokers == 0)
                     return 0;
             }
 

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -38,7 +38,7 @@ namespace Trickster.Bots
             var partnersBids = players.PartnersOf(player).Select(p => new FiveHundredBid(p.Bid)).ToList();
             var playerLastBid = player.BidHistory.Any() ? new FiveHundredBid(player.BidHistory.Last()) : new FiveHundredBid(BidBase.NoBid);
             var defaultPartnerTricks = players.Count == 3 ? 1 : 2;
-            var estimatedKittyTricks = (int)Math.Floor(KittySize / 3.0);
+            var estimatedKittyTricks = KittySize > 3 ? 1 : 0;
             var minimumToBid6NT = 6 - defaultPartnerTricks - estimatedKittyTricks;
 
             //  calculate the raw number of tricks we can take with a given trump suit
@@ -383,7 +383,7 @@ namespace Trickster.Bots
                 }
 
                 //  if we're looking at no-trump and we don't have a stopper in all suits, bail
-                if (trumpSuit == Suit.Unknown && !hasStopper && nJokers == 0)
+                if (trumpSuit == Suit.Unknown && !hasStopper && remainingJokers <= 0)
                     return 0;
             }
 


### PR DESCRIPTION
Ref #202

Reduces the number of tricks estimated for a 5/6-card kitty from two to one.

Also fixes a play-of-the-hand issue affecting 500, Oh Hell, and Whist where the bot wouldn't trump in when playing 2nd to the trick, even if the led card was high.