### PR TITLE
Hearts: Don't play QS on partner

### DIFF
--- a/TestBots/TestHeartsBot.cs
+++ b/TestBots/TestHeartsBot.cs
@@ -65,6 +65,7 @@ namespace TestBots
 
         [TestMethod]
         [DataRow("8S",   "KSTS", "QS8S", DisplayName = "Don't play QS if partner taking trick with higher spade")]
+        [DataRow("AS",   "KSTS", "QSAS", DisplayName = "Don't play QS if partner taking trick with higher spade, even holding AS")]
         [DataRow("8S", "4SKSTS", "QS8S", DisplayName = "Don't play QS if last to play and partner taking trick")]
         public void PlayOfHandAfterFirstTrick(string card, string trick, string hand)
         {

--- a/TestBots/TestHeartsBot.cs
+++ b/TestBots/TestHeartsBot.cs
@@ -62,6 +62,31 @@ namespace TestBots
             Assert.AreEqual("TS", suggestion.ToString(), $"Suggested {suggestion.StdNotation}; expected lowest spade (ten)");
         }
 
+
+        [TestMethod]
+        [DataRow("8S",   "KSTS", "QS8S", DisplayName = "Don't play QS if partner taking trick with higher spade")]
+        [DataRow("8S", "4SKSTS", "QS8S", DisplayName = "Don't play QS if last to play and partner taking trick")]
+        public void PlayOfHandAfterFirstTrick(string card, string trick, string hand)
+        {
+            var players = new[]
+            {
+                new TestPlayer(hand: hand, cardsTaken: "2CACKCQC"),
+                new TestPlayer(),
+                new TestPlayer(),
+                new TestPlayer()
+            };
+
+            var options = new HeartsOptions
+            {
+                isPartnership = true
+            };
+
+            var bot = GetBot(options);
+            var cardState = new TestCardState<HeartsOptions>(bot, players, trick);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual(card, suggestion.ToString());
+        }
+
         private static HeartsBot GetBot()
         {
             return GetBot(new HeartsOptions());

--- a/TricksterBots/Bots/Hearts/HeartsBot.cs
+++ b/TricksterBots/Bots/Hearts/HeartsBot.cs
@@ -132,8 +132,8 @@ namespace Trickster.Bots
                     cardsBelowHighestPlayed = cardsBelowHighestPlayed.Where(c => c.rank < Rank.Jack).ToList();
 
                 //  exclude the Q♠ if we have it and our partner is taking the trick with a higher spade
-                if (queenSpades != null && isPartnerTakingTrick && cardTakingTrick.rank > Rank.Queen)
-                    cardsBelowHighestPlayed = cardsBelowHighestPlayed.Where(c => c.rank != Rank.Queen).ToList();
+                if (queenSpades != null && isPartnerTakingTrick && cardTakingTrick.suit == Suit.Spades && cardTakingTrick.rank > Rank.Queen)
+                    cardsBelowHighestPlayed = cardsBelowHighestPlayed.Where(c => !IsBlackLady(c)).ToList();
 
                 if (cardsBelowHighestPlayed.Any())
                 {

--- a/TricksterBots/Bots/Hearts/HeartsBot.cs
+++ b/TricksterBots/Bots/Hearts/HeartsBot.cs
@@ -131,6 +131,10 @@ namespace Trickster.Bots
                     //  if we might be able to take the J♦ later, don't throw high diamonds now
                     cardsBelowHighestPlayed = cardsBelowHighestPlayed.Where(c => c.rank < Rank.Jack).ToList();
 
+                //  exclude the Q♠ if we have it and our partner is taking the trick with a higher spade
+                if (queenSpades != null && isPartnerTakingTrick && cardTakingTrick.rank > Rank.Queen)
+                    cardsBelowHighestPlayed = cardsBelowHighestPlayed.Where(c => c.rank != Rank.Queen).ToList();
+
                 if (cardsBelowHighestPlayed.Any())
                 {
                     var highestRankBelowHighestPlayed = cardsBelowHighestPlayed.Max(c => c.rank);


### PR DESCRIPTION
Fix #209 

This was missing a case where partner was taking the trick with KS or AS (and the bot was not last to play).

Fixed by adding an extra check if partner is taking the trick with a high spade and filtering out the QS from available options if so.