### PR TITLE
Euchre: Don't go alone if opponents pick up high

### DIFF
--- a/TestBots/TestEuchreBot.cs
+++ b/TestBots/TestEuchreBot.cs
@@ -22,10 +22,10 @@ namespace TestBots
             {
                 players = new[]
                 {
-                    new TestPlayer(hand: handString),
-                    new TestPlayer(),
-                    new TestPlayer(),
-                    new TestPlayer()
+                    new TestPlayer(seat: 0, hand: handString),
+                    new TestPlayer(seat: 1),
+                    new TestPlayer(seat: 2),
+                    new TestPlayer(seat: 3)
                 },
                 dealerSeat = 3,
                 hand = new Hand(handString),
@@ -400,6 +400,8 @@ namespace TestBots
         [DataRow("♠ alone", " ACKC AH JCJS", "9S",  true, false, DisplayName = "Should bid alone if call-for-best with only Jacks with strong off-suit support")]
         //  but don't count on anything extra from partner if alone must take 5 is enabled
         [DataRow(      "♠", " ACKC AH JCJS", "9S",  true,  true, DisplayName = "Should not bid alone if alone-must-take-5 even with call-for-best")]
+        [DataRow("♠ alone", "  AH QSKSASJC", "9S",  true, false, DisplayName = "Should go alone without high Jack if strong enough")]
+        [DataRow(      "♠", "  AH QSKSASJC", "JS",  true, false, DisplayName = "Should not go alone if opponents will pick up high Jack")]
         //  odds are good we can take these alone - if partner has A in our offsuit, we'll likely be good even if they sit out
         [DataRow("♣ alone", "  ADKD ACJSJC", "9C", false, false, DisplayName = "Bid alone with top three trump, two-suited, and top off-suit")]
         [DataRow("♣ alone", " AD AH ACJSJC", "9C", false, false, DisplayName = "Bid alone with top three trump and top off-suit")]
@@ -505,10 +507,10 @@ namespace TestBots
             {
                 players = new[]
                 {
-                    new TestPlayer(hand: handString),
-                    new TestPlayer(),
-                    new TestPlayer(),
-                    new TestPlayer()
+                    new TestPlayer(seat: 0, hand: handString),
+                    new TestPlayer(seat: 1),
+                    new TestPlayer(seat: 2),
+                    new TestPlayer(seat: 3)
                 },
                 dealerSeat = 3,
                 hand = new Hand(handString),

--- a/TricksterBots/Bots/Euchre/EuchreBot.cs
+++ b/TricksterBots/Bots/Euchre/EuchreBot.cs
@@ -94,6 +94,7 @@ namespace Trickster.Bots
                 return new BidBase(BidBase.Pass);
 
             var isDealer = player.Seat == dealerSeat;
+            var isTeamDealing = isDealer || players.PartnersOf(player).Any(p => p.Seat == dealerSeat);
 
             //  always call a misdeal if offered
             if (legalBids.Any(b => b.value == (int)EuchreBid.CallMisdeal))
@@ -102,15 +103,15 @@ namespace Trickster.Bots
             if (legalBids.Any(b => b.value == (int)EuchreBid.GoUnder))
             {
                 //  go under if we can and don't have any suit we think we want to bid
-                var bestBid = SuggestBid(hand, upCard, upCardSuit, isDealer);
+                var bestBid = SuggestBid(hand, upCard, upCardSuit, isDealer, isTeamDealing, canPass: true);
 
                 if (bestBid.value == BidBase.Pass && upCard != null)
-                    bestBid = SuggestBid(hand, null, upCardSuit, isDealer);
+                    bestBid = SuggestBid(hand, null, upCardSuit, isDealer, isTeamDealing, canPass: true);
 
                 return legalBids.Single(b => b.value == (bestBid.value == BidBase.Pass ? (int)EuchreBid.GoUnder : (int)EuchreBid.AfterGoUnder));
             }
 
-            var suggestion = SuggestBid(hand, upCard, upCardSuit, isDealer, legalBids.Any(b => b.value == BidBase.Pass));
+            var suggestion = SuggestBid(hand, upCard, upCardSuit, isDealer, isTeamDealing, legalBids.Any(b => b.value == BidBase.Pass));
             var canBidSuggestion = legalBids.Any(b => b.value == suggestion.value);
 
             if (!canBidSuggestion && IsAloneBid(suggestion))
@@ -133,7 +134,7 @@ namespace Trickster.Bots
         }
 
         //  overload called above and for unit tests
-        public BidBase SuggestBid(Hand hand, Card upCard, Suit upCardSuit, bool isDealer, bool canPass = true)
+        public BidBase SuggestBid(Hand hand, Card upCard, Suit upCardSuit, bool isDealer, bool isTeamDealing, bool canPass)
         {
             var highSuit = Suit.Unknown;
             var highEstimate = 0.0;
@@ -173,7 +174,10 @@ namespace Trickster.Bots
 
             //  bid alone if we think we'll take at least 4-tricks, so long as we hold the appropriate high cards
             //  only require just under 3-tricks if call-for-best is on (as we'll likely get another trump from partner)
-            if (highEstimate >= (options.callForBest && !options.aloneTake5 ? 2.75 : 4.0))
+            //  and make sure to not go alone if the up-card is high and will be picked up by the opponents
+            var upCardIsHigh = upCard != null && (options.withJoker ? upCard.rank == Rank.High : upCard.rank == Rank.Jack);
+            var opponentsHaveHigh = upCardIsHigh && !isTeamDealing;
+            if (!opponentsHaveHigh && highEstimate >= (options.callForBest && !options.aloneTake5 && !options.take4for1 ? 2.75 : 4.0))
             {
                 //  when aloneTake5 is true, we need to hold the Joker (if present) or the high Jack to bid alone (plus high in each off-suit)
                 if (options.aloneTake5 && hand.Any(c => options.withJoker ? c.rank == Rank.High : c.suit == highSuit && c.rank == Rank.Jack) && hand.All(c => EffectiveSuit(c, highSuit) == highSuit || hand.Any(h => h.rank == Rank.Ace && h.suit == c.suit)))

--- a/TricksterBots/Bots/Euchre/EuchreBot.cs
+++ b/TricksterBots/Bots/Euchre/EuchreBot.cs
@@ -133,8 +133,8 @@ namespace Trickster.Bots
             return !IsAloneBid(bid) ? bid : new BidBase(bid.value - (int)EuchreBid.MakeAlone + (int)EuchreBid.Make);
         }
 
-        //  overload called above and for unit tests
-        public BidBase SuggestBid(Hand hand, Card upCard, Suit upCardSuit, bool isDealer, bool isTeamDealing, bool canPass)
+        //  overload called above
+        private BidBase SuggestBid(Hand hand, Card upCard, Suit upCardSuit, bool isDealer, bool isTeamDealing, bool canPass)
         {
             var highSuit = Suit.Unknown;
             var highEstimate = 0.0;


### PR DESCRIPTION
Fix #227

Keeps the bot from going alone when it is guaranteed to not take all 5 tricks because the up-card is high and the opponents are dealing.

Also handles if the Joker is in play.