### PR TITLE
Use deckType from options classes

### DIFF
--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -50,8 +50,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="TricksterBotClasses, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\TricksterBotClasses.1.2.1\lib\net48\TricksterBotClasses.dll</HintPath>
+    <Reference Include="TricksterBotClasses, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\TricksterBotClasses.1.3.0\lib\net48\TricksterBotClasses.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/TestBots/packages.config
+++ b/TestBots/packages.config
@@ -3,5 +3,5 @@
   <package id="MSTest.TestAdapter" version="2.2.10" targetFramework="net48" />
   <package id="MSTest.TestFramework" version="2.2.10" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
-  <package id="TricksterBotClasses" version="1.2.1" targetFramework="net48" />
+  <package id="TricksterBotClasses" version="1.3.0" targetFramework="net48" />
 </packages>

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -60,7 +60,7 @@ namespace Trickster.Bots
             return false;
         }
 
-        public abstract DeckType DeckType { get; }
+        public DeckType DeckType => options.deckType;
 
         public Suit EffectiveSuit(Card c)
         {

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -29,8 +29,6 @@ namespace Trickster.Bots
         {
         }
 
-        public override DeckType DeckType => DeckType.Std52Card;
-
         public static bool IsMajor(Suit s)
         {
             return s == Suit.Spades || s == Suit.Hearts;

--- a/TricksterBots/Bots/Euchre/EuchreBot.cs
+++ b/TricksterBots/Bots/Euchre/EuchreBot.cs
@@ -20,27 +20,7 @@ namespace Trickster.Bots
         {
         }
 
-        public override DeckType DeckType
-        {
-            get
-            {
-                switch (options.deckSize)
-                {
-                    case 20:
-                        return options.withJoker ? DeckType.TenToAceAndJoker : DeckType.TenToAce;
-                    case 24:
-                        return options.withJoker ? DeckType.NineToAceAndJoker : DeckType.NineToAce;
-                    case 28:
-                        return options.withJoker ? DeckType.EightToAceAndJoker : DeckType.EightToAce;
-                    case 32:
-                        return options.withJoker ? DeckType.SevenToAceAndJoker : DeckType.SevenToAce;
-                }
-
-                return DeckType.NineToAce;
-            }
-        }
-
-        public double EstimatedTricks(Hand hand, Suit maybeTrump, bool withJoker)
+        private double EstimatedTricks(Hand hand, Suit maybeTrump, bool withJoker)
         {
             //  ensure all suits have at least some value so we never pick Suit.Unknown
             var est = 0.1;

--- a/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
+++ b/TricksterBots/Bots/FiveHundred/FiveHundredBot.cs
@@ -11,24 +11,6 @@ namespace Trickster.Bots
         {
         }
 
-        public override DeckType DeckType
-        {
-            get
-            {
-                switch (options.deckSize)
-                {
-                    case 43:
-                        return options.players == 6 ? DeckType.FiveHundred63Card : options.players == 3 ? DeckType.FiveHundred33Card : DeckType.FiveHundred43Card;
-                    case 45:
-                        return options.players == 6 ? DeckType.FiveHundred65Card : DeckType.FiveHundred45Card;
-                    case 46:
-                        return options.players == 6 ? DeckType.FiveHundred66Card : DeckType.FiveHundred46Card;
-                    default:
-                        return options.players == 6 ? DeckType.FiveHundred63Card : DeckType.FiveHundred43Card;
-                }
-            }
-        }
-
         private int KittySize => options.deckSize - 40;
 
         public override BidBase SuggestBid(SuggestBidState<FiveHundredOptions> state)

--- a/TricksterBots/Bots/Hearts/HeartsBot.cs
+++ b/TricksterBots/Bots/Hearts/HeartsBot.cs
@@ -11,24 +11,6 @@ namespace Trickster.Bots
         {
         }
 
-        public override DeckType DeckType
-        {
-            get
-            {
-                switch (options.players)
-                {
-                    case 3:
-                        return DeckType.No2D_51Card;
-                    case 5:
-                        return DeckType.No2C2D_50Card;
-                    case 6:
-                        return DeckType.No2C2D2S3C_48Card;
-                    default:
-                        return DeckType.Std52Card;
-                }
-            }
-        }
-
         private int JackOfDiamondsValue => options.jackOfDiamonds ? -10 : options.jackOfDiamondsForMinus5 ? -5 : 0;
 
         public override BidBase SuggestBid(SuggestBidState<HeartsOptions> state)

--- a/TricksterBots/Bots/OhHell/OhHellBot.cs
+++ b/TricksterBots/Bots/OhHell/OhHellBot.cs
@@ -11,8 +11,6 @@ namespace Trickster.Bots
         {
         }
 
-        public override DeckType DeckType => DeckType.Std52Card;
-
         public override BidBase SuggestBid(SuggestBidState<OhHellOptions> state)
         {
             var hand = state.hand;

--- a/TricksterBots/Bots/Pinochle/PinochleBot.cs
+++ b/TricksterBots/Bots/Pinochle/PinochleBot.cs
@@ -11,8 +11,6 @@ namespace Trickster.Bots
         {
         }
 
-        public override DeckType DeckType => options.doubleDeck ? DeckType.Pinochle80 : DeckType.Pinochle48;
-
         public override BidBase SuggestBid(SuggestBidState<PinochleOptions> state)
         {
             var (legalBids, players, player, hand) = (state.legalBids, new PlayersCollectionBase(this, state.players), state.player, state.hand);

--- a/TricksterBots/Bots/Pitch/PitchBot.cs
+++ b/TricksterBots/Bots/Pitch/PitchBot.cs
@@ -39,54 +39,15 @@ namespace Trickster.Bots
         {
         }
 
-        public override DeckType DeckType
-        {
-            get
-            {
-                switch (options.variation)
-                {
-                    case PitchVariation.FourPoint:
-                    case PitchVariation.FivePoint:
-                        return options.deck;
-                    case PitchVariation.NinePoint:
-                        return DeckType.Std52Card;
-                    case PitchVariation.SixPoint:
-                        switch (options.deck)
-                        {
-                            case DeckType.Std52Card:
-                                return DeckType.Std53Card;
-                            case DeckType.TwoAndNineToAce:
-                                return DeckType.TwoAndNineToAceAndJoker;
-                            case DeckType.FiveToAce:
-                                return DeckType.FiveToAceAndJoker;
-                            case DeckType.NineToAce:
-                                return DeckType.NineToAceAndJoker;
-                            default:
-                                throw new Exception($"Unrecognized deck type: {options.deck}");
-                        }
-                    case PitchVariation.SevenPoint:
-                    case PitchVariation.TenPoint:
-                    case PitchVariation.ElevenPoint:
-                    case PitchVariation.ThirteenPoint:
-                        if (options.players == 5 && options.kitty == 0)
-                            return DeckType.No4s_50Card; //  5-player call your partner w/o a kitty (10 cards to each player)
-                        else
-                            return DeckType.Std54Card;
-                    default:
-                        throw new Exception($"Unrecognized Pitch variation: {options.variation}");
-                }
-            }
-        }
-
         private bool HasPostBidDiscard => autoDiscardVariations.Contains(options.variation);
 
         private bool IsCallPartner => options.players > 4 && !options.isPartnership;
 
-        private bool IsOffAceTrump => options.variation == PitchVariation.ElevenPoint;
+        //private bool IsOffAceTrump => options.variation == PitchVariation.ElevenPoint;
 
-        private bool IsOffJackTrump => options.variation != PitchVariation.FourPoint && options.variation != PitchVariation.NinePoint;
+        //private bool IsOffJackTrump => options.variation != PitchVariation.FourPoint && options.variation != PitchVariation.NinePoint;
 
-        private bool IsOffThreeTrump => PitchOptions.availablePoints[options.variation] >= 13;
+        //private bool IsOffThreeTrump => PitchOptions.availablePoints[options.variation] >= 13;
 
         private bool IsRankFiveWorth5 => options.variation == PitchVariation.NinePoint;
 
@@ -779,7 +740,7 @@ namespace Trickster.Bots
 
         private int GamePointsX2(Card card)
         {
-            return !options.tenOfTrumpReplacesGamePoint && gamePointsByRank.ContainsKey(card.rank) ? gamePointsByRank[card.rank] : 0;
+            return !options.tenOfTrumpReplacesGamePoint && gamePointsByRank.TryGetValue(card.rank, out var pts) ? pts : 0;
         }
 
         private int GetMaxDiscardCount(PlayerBase player, List<Card> legalDiscards)

--- a/TricksterBots/Bots/Spades/SpadesBot.cs
+++ b/TricksterBots/Bots/Spades/SpadesBot.cs
@@ -20,24 +20,7 @@ namespace Trickster.Bots
         {
         }
 
-        public override DeckType DeckType
-        {
-            get
-            {
-                switch (options.variation)
-                {
-                    case SpadesVariation.JokerJokerAce:
-                    case SpadesVariation.JokerJokerDeuceAce:
-                    case SpadesVariation.JokerJokerDeuceDeuce:
-                        return options.players == 3 ? DeckType.Std54Card : DeckType.SpadesWithJokers;
-
-                    default:
-                        return options.players == 3 ? DeckType.No2C_51Card : DeckType.Std52Card;
-                }
-            }
-        }
-        
-        public double EstimatedTricks(Hand hand)
+        private double EstimatedTricks(Hand hand)
         {
             var est = 0.0;
             var noJokers = DeckType != DeckType.SpadesWithJokers;

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -11,8 +11,6 @@ namespace Trickster.Bots
         {
         }
 
-        public override DeckType DeckType => options.DeckType;
-
         public override BidBase SuggestBid(SuggestBidState<WhistOptions> state)
         {
             var hand = state.hand;

--- a/TricksterBots/TricksterBots.csproj
+++ b/TricksterBots/TricksterBots.csproj
@@ -72,8 +72,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="TricksterBotClasses, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\TricksterBotClasses.1.2.1\lib\net48\TricksterBotClasses.dll</HintPath>
+    <Reference Include="TricksterBotClasses, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\TricksterBotClasses.1.3.0\lib\net48\TricksterBotClasses.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/TricksterBots/packages.config
+++ b/TricksterBots/packages.config
@@ -10,5 +10,5 @@
   <package id="System.Text.Json" version="6.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="TricksterBotClasses" version="1.2.1" targetFramework="net48" />
+  <package id="TricksterBotClasses" version="1.3.0" targetFramework="net48" />
 </packages>

--- a/WebAPI/WebAPI.csproj
+++ b/WebAPI/WebAPI.csproj
@@ -137,8 +137,8 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
-    <Reference Include="TricksterBotClasses, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\TricksterBotClasses.1.2.1\lib\net48\TricksterBotClasses.dll</HintPath>
+    <Reference Include="TricksterBotClasses, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\TricksterBotClasses.1.3.0\lib\net48\TricksterBotClasses.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/WebAPI/packages.config
+++ b/WebAPI/packages.config
@@ -17,5 +17,5 @@
   <package id="System.Text.Json" version="6.0.4" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="TricksterBotClasses" version="1.2.1" targetFramework="net48" />
+  <package id="TricksterBotClasses" version="1.3.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Remove computation of DeckType from bots and use from options class

And fix a couple of other ReSharper-suggested things on the way.