### PR TITLE
Fix bad Euchre discards/passes

### DIFF
--- a/TricksterBots/Bots/Euchre/EuchreBot.cs
+++ b/TricksterBots/Bots/Euchre/EuchreBot.cs
@@ -194,8 +194,8 @@ namespace Trickster.Bots
                         lowRank = hand.Where(c => EffectiveSuit(c) == s).Min(RankSort),
                         highRank = hand.Where(c => EffectiveSuit(c) == s).Max(RankSort)
                     })
-                    .OrderBy(sc => sc.lowRank == (int)Rank.Ace) //  don't get rid of off-suit Aces unless we have to
-                    .ThenBy(sc => sc.count == 2 && sc.highRank == (int)Rank.King) //  don't get rid of protection for an off-suit King unless we have to
+                    .OrderBy(sc => sc.lowRank == RankSort(new Card(sc.suit, Rank.Ace))) //  don't get rid of off-suit Aces unless we have to
+                    .ThenBy(sc => sc.count == 2 && sc.highRank == RankSort(new Card(sc.suit, Rank.King))) //  don't get rid of protection for an off-suit King unless we have to
                     .ThenBy(sc => sc.count)
                     .ThenBy(sc => sc.lowRank)
                     .FirstOrDefault();

--- a/TricksterBots/Bots/Euchre/EuchreBot.cs
+++ b/TricksterBots/Bots/Euchre/EuchreBot.cs
@@ -184,12 +184,19 @@ namespace Trickster.Bots
             if (player.Bid == (int)EuchreBid.GoUnder)
                 return hand.OrderBy(IsTrump).ThenBy(RankSort).Take(3).ToList();
 
-            //  discard the lowest card of the offsuit with the fewest cards (or the lowest card of trump)
+            //  discard the lowest card of the off-suit with the fewest cards (or the lowest card of trump)
             var offSuits = hand.Select(EffectiveSuit).Where(s => s != trump).Distinct().ToList();
             var lowSuitCount =
                 offSuits.Select(s => new
-                        { suit = s, count = hand.Count(c => EffectiveSuit(c) == s), lowRank = hand.Where(c => EffectiveSuit(c) == s).Min(RankSort) })
-                    .OrderBy(sc => sc.count)
+                    {
+                        suit = s,
+                        count = hand.Count(c => EffectiveSuit(c) == s),
+                        lowRank = hand.Where(c => EffectiveSuit(c) == s).Min(RankSort),
+                        highRank = hand.Where(c => EffectiveSuit(c) == s).Max(RankSort)
+                    })
+                    .OrderBy(sc => sc.lowRank == (int)Rank.Ace) //  don't get rid of off-suit Aces unless we have to
+                    .ThenBy(sc => sc.count == 2 && sc.highRank == (int)Rank.King) //  don't get rid of protection for an off-suit King unless we have to
+                    .ThenBy(sc => sc.count)
                     .ThenBy(sc => sc.lowRank)
                     .FirstOrDefault();
             var lowSuit = lowSuitCount?.suit ?? trump;


### PR DESCRIPTION
Fix #233

The discard algorithm (also used for passing a card away from the maker in call-for-best) is pretty simple and could sometimes lead to passing good off-suit cards, especially in no trump.

Fixed by adding a couple of extra early sort conditions to prefer keeping off-suit Aces and protected Kings if possible.