### PR TITLE
Spades: Play "first hand bids itself" sensibly

### DIFF
--- a/TestBots/TestSpadesBot.cs
+++ b/TestBots/TestSpadesBot.cs
@@ -26,6 +26,25 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void PlayHandThatBidItself()
+        {
+            var players = new[]
+            {
+                new TestPlayer(hand: "AC3C"),
+                new TestPlayer(hand: "3H"),
+                new TestPlayer(hand: "4H"),
+                new TestPlayer(hand: "5H"),
+            };
+
+            var bot = GetBot();
+            var cardState = new TestCardState<SpadesOptions>(bot, players, "4C5C6C");
+            var suggestion = bot.SuggestNextCard(cardState);
+
+            //  should try to take tricks when playing "first hand bid itself" (e.g. our bid is BidBase.NoBid)
+            Assert.AreEqual("AC", suggestion.ToString(), $"Suggested {suggestion.StdNotation}; expected AC");
+        }
+
+        [TestMethod]
         [DataRow("2H3H", "JH5H",   "", "JH")]
         [DataRow("3H2H", "JH5H",   "", "JH")]
         [DataRow("9HTH", "QHJH",   "", "JH")]

--- a/TricksterBots/Bots/Spades/SpadesBot.cs
+++ b/TricksterBots/Bots/Spades/SpadesBot.cs
@@ -669,6 +669,10 @@ namespace Trickster.Bots
             //  look for our team's nil bids
             var playerBid = new SpadesBid(player.Bid);
 
+            //  always try to take tricks if "first hand bids itself"
+            if (playerBid.IsNoBid)
+                return TryTakeEm(player, trick, legalCards, cardsPlayed, players, isPartnerTakingTrick, cardTakingTrick, trickTaker);
+
             if (partner != null)
             {
                 //  try to make my own nil bid first


### PR DESCRIPTION
Makes the bot always try to take tricks when it doesn't have a bid (which happens when playing "first hand bids itself").

Prior to this change, the bot would try to avoid taking tricks in this scenario.