### PR TITLE
Euchre: Fix suggest card error with double-deck

### DIFF
--- a/TestBots/Euchre/BidEuchre/Leads.ptn
+++ b/TestBots/Euchre/BidEuchre/Leads.ptn
@@ -1,0 +1,15 @@
+[Event "Avoid leading trump on defense"]
+[GameOptionsJson "{\"gameOverScore\":30,\"variation\":1,\"numDecks\":2,\"deckSize\":16}"]
+[Deal "N:- QT.QT.K9.JJ - -"]
+[Declarer "N"]
+[Contract "4♣"]
+[Play "E"]
+D9 - - -
+
+[Event "Lead high card with 2+ high cards"]
+[GameOptionsJson "{\"gameOverScore\":30,\"variation\":1,\"numDecks\":2,\"deckSize\":16}"]
+[Deal "N:- QT.QT.K9.JJ - -"]
+[Declarer "E"]
+[Contract "4♣"]
+[Play "E"]
+CJ - - -

--- a/TestBots/PTN.cs
+++ b/TestBots/PTN.cs
@@ -283,36 +283,12 @@ namespace TestBots.Bridge
                 if (hands[i] == string.Empty)
                     hands[i] = string.Join(string.Empty, Enumerable.Repeat(UnknownCard, nCardsPerPlayer));
 
-            // validate known hands are of the correct length with no shared cards
+            // validate known hands are of the correct length
             var knownHands = hands.Where(h => !IsUnknownHand(h)).ToList();
-            var cardCounts = new Dictionary<string, int>();
             foreach (var hand in knownHands)
             {
                 if (hand.Length != nCardsPerPlayer * 2)
                     throw new ArgumentException($"Hand without exactly {nCardsPerPlayer} cards found in '{handsString}'");
-
-                for (var i = 0; i < hand.Length; i += 2)
-                {
-                    var card = hand.Substring(i, 2);
-                    if (!cardCounts.ContainsKey(card))
-                        cardCounts[card] = 1;
-                    else
-                        cardCounts[card]++;
-                }
-            }
-
-            var max = cardCounts.Values.Max();
-            var min = cardCounts.Values.Min();
-
-            if (max != min)
-            {
-                var under = cardCounts.Where(kv => kv.Value < max).Select(kv => kv.Key).ToList();
-                var over = cardCounts.Where(kv => kv.Value > min).Select(kv => kv.Key).ToList();
-
-                if (over.Count > under.Count)
-                    throw new ArgumentException($"Missing some instances of {string.Join(",", under)} in '{handsString}'");
-
-                throw new ArgumentException($"Extra instances of {string.Join(",", under)} found in '{handsString}'");
             }
 
             return (dealerSeat, hands, nPlayers, nCardsPerPlayer);

--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -129,6 +129,9 @@
     <Content Include="Euchre\BidEuchre\Last to Bid.ptn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Euchre\BidEuchre\Leads.ptn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/TricksterBots/Bots/Euchre/EuchreBot.cs
+++ b/TricksterBots/Bots/Euchre/EuchreBot.cs
@@ -427,8 +427,11 @@ namespace Trickster.Bots
 
                     //  play the high non-trump card from the suit with fewest cards
                     var nonTrumpHighCards = highCards.Where(c => !IsTrump(c)).ToList();
-                    var theSuit = nonTrumpHighCards.Select(EffectiveSuit).OrderBy(s => legalCards.Count(c => EffectiveSuit(c) == s)).ThenBy(s => suitOrder[s]).First();
-                    return nonTrumpHighCards.First(c => EffectiveSuit(c) == theSuit);
+                    if (nonTrumpHighCards.Any())
+                    {
+                        var theSuit = nonTrumpHighCards.Select(EffectiveSuit).OrderBy(s => legalCards.Count(c => EffectiveSuit(c) == s)).ThenBy(s => suitOrder[s]).First();
+                        return nonTrumpHighCards.First(c => EffectiveSuit(c) == theSuit);
+                    }
                 }
 
                 //  lead our highest off-suit if we're alone, out of trump and opponents haven't taken a trick yet


### PR DESCRIPTION
This happened on defense if the bot had two of the same high trump card, but no high off-suit cards. Fixed by checking if there are any high off-suit cards first.

Also removes some validation on PTN import that was conflicting with partial PTNs for double-deck games.