### PR TITLE
Bridge: Fix comparing suit ranks

### DIFF
--- a/TestBots/Bridge/SAYC/Response.pbn
+++ b/TestBots/Bridge/SAYC/Response.pbn
@@ -1,0 +1,6 @@
+
+[Event "Respond with game-going strength"]
+[Deal "S:AKQJT3.AT.72.KQ6 984.86.KQT83.987 5.KQ9752.A64.AJ4 762.J43.J95.T532"]
+[Auction "S"]
+1S Pass 2H Pass
+

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 10/3/2023 3:25 PM (-07:00)
+// last updated 10/1/2024 5:23 PM (-05:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -871,11 +871,11 @@ namespace TestBots
                     new SaycResult(true, 402, 402),
                     new SaycResult(true, 422, 422),
                     new SaycResult(false, 421, 432), // last run result: 2♣; expected: 3♥;
-                    new SaycResult(false, 423, 432), // last run result: 2♠; expected: 3♥;
+                    new SaycResult(false, -2, 432), // last run result: Pass; expected: 3♥;
                     new SaycResult(true, 402, 402),
                     new SaycResult(true, 423, 423),
                     new SaycResult(false, -2, 424), // last run result: Pass; expected: 2♥;
-                    new SaycResult(true, 423, 423),
+                    new SaycResult(false, 429, 423), // last run result: 3♣; expected: 2♠;
                     new SaycResult(true, 402, 402),
                     new SaycResult(false, 431, 402), // last run result: 3♠; expected: X;
                     new SaycResult(false, 429, 430), // last run result: 3♣; expected: 3♦;
@@ -989,7 +989,7 @@ namespace TestBots
                     new SaycResult(true, 428, 428),
                     new SaycResult(true, 423, 423),
                     new SaycResult(true, -2, -2),
-                    new SaycResult(true, 424, 424),
+                    new SaycResult(false, 432, 424), // last run result: 3♥; expected: 2♥;
                     new SaycResult(false, -2, 431), // last run result: Pass; expected: 3♠;
                     new SaycResult(true, 423, 423),
                     new SaycResult(true, -2, -2),

--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -131,6 +131,9 @@
     <Content Include="Euchre\BidEuchre\Leads.ptn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Bridge\SAYC\Response.pbn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/OpenerRebid.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/OpenerRebid.cs
@@ -293,7 +293,7 @@ namespace Trickster.Bots
                     rebid.HandShape[rebid.declareBid.suit].Min = 4;
                     rebid.Description = $"New suit; 4+ {rebid.declareBid.suit}";
                 }
-                else if (rebid.declareBid.suit > opening.declareBid.suit && rebid.declareBid.level == lowestAvailableLevel)
+                else if (BridgeBot.suitRank[rebid.declareBid.suit] > BridgeBot.suitRank[opening.declareBid.suit] && rebid.declareBid.level == lowestAvailableLevel)
                 {
                     //  medium: REVERSE in a new suit (16-21 points)
                     rebid.Points.Min = 16;

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
@@ -385,10 +385,10 @@ namespace Trickster.Bots
                             {
                                 //  changing suits
                                 response.BidMessage = BidMessage.Forcing;
-                                response.Points.Min = response.declareBid.suit > opening.declareBid.suit ? 17 : 11;
+                                response.Points.Min = BridgeBot.suitRank[response.declareBid.suit] > BridgeBot.suitRank[opening.declareBid.suit] ? 17 : 11;
                                 response.HandShape[response.declareBid.suit].Min = BridgeBot.IsMinor(response.declareBid.suit) ? 4 : 5;
                                 response.Description =
-                                    $"{response.HandShape[response.declareBid.suit].Min}+ {response.declareBid.suit}{(response.declareBid.suit > opening.declareBid.suit ? "; slam interest" : string.Empty)}";
+                                    $"{response.HandShape[response.declareBid.suit].Min}+ {response.declareBid.suit}{(BridgeBot.suitRank[response.declareBid.suit] > BridgeBot.suitRank[opening.declareBid.suit] ? "; slam interest" : string.Empty)}";
                             }
 
                             break;
@@ -556,7 +556,7 @@ namespace Trickster.Bots
                             {
                                 //  changing suits
                                 response.BidMessage = BidMessage.Forcing;
-                                response.Points.Min = response.declareBid.suit > opening.declareBid.suit ? 17 : 11;
+                                response.Points.Min = BridgeBot.suitRank[response.declareBid.suit] > BridgeBot.suitRank[opening.declareBid.suit] ? 17 : 11;
                                 response.HandShape[response.declareBid.suit].Min = 5;
                                 response.SetHandShapeMaxesOfOtherSuits(response.declareBid.suit, 6);
                                 response.Description = $"5+ {response.declareBid.suit}; slam interest";


### PR DESCRIPTION
Fix #287

Most code was already using `suitRank` for these types of comparisons, but a few places were missed.