### PR TITLE
Bridge: Relax balanced checks responding to NT openings

### DIFF
--- a/TestBots/Bridge/SAYC/Response.pbn
+++ b/TestBots/Bridge/SAYC/Response.pbn
@@ -1,6 +1,11 @@
 
 [Event "Respond with game-going strength"]
-[Deal "S:AKQJT3.AT.72.KQ6 984.86.KQT83.987 5.KQ9752.A64.AJ4 762.J43.J95.T532"]
+[Deal "S:- - 5.KQ9752.A64.AJ4 -"]
 [Auction "S"]
 1S Pass 2H Pass
+
+[Event "Respond to NT with game-going strength"]
+[Deal "E:- - - Q.K73.KQ843.AJ54"]
+[Auction "E"]
+Pass 1NT Pass 3NT
 

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 10/1/2024 5:23 PM (-05:00)
+// last updated 10/3/2024 3:18 PM (-05:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -967,7 +967,7 @@ namespace TestBots
                     new SaycResult(false, 422, 415), // last run result: 2♦; expected: 1♠;
                     new SaycResult(true, 440, 440),
                     new SaycResult(true, 428, 428),
-                    new SaycResult(false, -2, 421), // last run result: Pass; expected: 2♣;
+                    new SaycResult(false, 428, 421), // last run result: 3NT; expected: 2♣;
                     new SaycResult(false, -2, 428), // last run result: Pass; expected: 3NT;
                     new SaycResult(false, 422, 428), // last run result: 2♦; expected: 3NT;
                     new SaycResult(false, 421, -2), // last run result: 2♣; expected: Pass;
@@ -993,7 +993,7 @@ namespace TestBots
                     new SaycResult(false, -2, 431), // last run result: Pass; expected: 3♠;
                     new SaycResult(true, 423, 423),
                     new SaycResult(true, -2, -2),
-                    new SaycResult(false, -2, 428), // last run result: Pass; expected: 3NT;
+                    new SaycResult(true, 428, 428),
                     new SaycResult(true, -2, -2),
                     new SaycResult(false, 429, -2), // last run result: 3♣; expected: Pass;
                     new SaycResult(false, -2, 422), // last run result: Pass; expected: 2♦;

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
@@ -143,6 +143,19 @@ namespace Trickster.Bots
                         response.Points.Max = 9;
                         response.IsBalanced = true;
                         response.Description = string.Empty;
+                        //  also use this bid when we're not balanced if nothing else fits
+                        response.AlternateMatches = hand =>
+                        {
+                            var hcp = BasicBidding.ComputeHighCardPoints(hand);
+                            var counts = BasicBidding.CountsBySuit(hand);
+                            return !BasicBidding.IsBalanced(hand)
+                                && hcp >= 8
+                                && hcp <= 9
+                                && counts[Suit.Spades] < 4
+                                && counts[Suit.Hearts] < 4
+                                && counts[Suit.Diamonds] < 6
+                                && counts[Suit.Clubs] < 6;
+                        };
                     }
                     else
                     {
@@ -168,6 +181,19 @@ namespace Trickster.Bots
                         response.Points.Max = 15;
                         response.IsBalanced = true;
                         response.Description = string.Empty;
+                        //  also use this bid when we're not balanced if nothing else fits
+                        response.AlternateMatches = hand =>
+                        {
+                            var hcp = BasicBidding.ComputeHighCardPoints(hand);
+                            var counts = BasicBidding.CountsBySuit(hand);
+                            return !BasicBidding.IsBalanced(hand)
+                                && hcp >= 10
+                                && hcp <= 15
+                                && counts[Suit.Spades] < 4
+                                && counts[Suit.Hearts] < 4
+                                && counts[Suit.Diamonds] < 6
+                                && counts[Suit.Clubs] < 6;
+                        };
                     }
                     else if (BridgeBot.IsMajor(response.declareBid.suit))
                     {
@@ -224,6 +250,19 @@ namespace Trickster.Bots
                         response.BidPointType = BidPointType.Hcp;
                         response.BidMessage = BidMessage.Signoff;
                         response.IsBalanced = true;
+                        //  also use this bid when we're not balanced if nothing else fits
+                        response.AlternateMatches = hand =>
+                        {
+                            var hcp = BasicBidding.ComputeHighCardPoints(hand);
+                            var counts = BasicBidding.CountsBySuit(hand);
+                            return !BasicBidding.IsBalanced(hand)
+                                && hcp >= 18
+                                && hcp <= 19
+                                && counts[Suit.Spades] < 4
+                                && counts[Suit.Hearts] < 4
+                                && counts[Suit.Diamonds] < 6
+                                && counts[Suit.Clubs] < 6;
+                        };
                     }
 
                     break;
@@ -244,6 +283,17 @@ namespace Trickster.Bots
                         response.Points.Max = 10;
                         response.IsBalanced = true;
                         response.Description = string.Empty;
+                        //  also use this bid when we're not balanced if nothing else fits
+                        response.AlternateMatches = hand =>
+                        {
+                            var hcp = BasicBidding.ComputeHighCardPoints(hand);
+                            var counts = BasicBidding.CountsBySuit(hand);
+                            return !BasicBidding.IsBalanced(hand)
+                                && hcp >= 4
+                                && hcp <= 10
+                                && counts[Suit.Spades] < 4
+                                && counts[Suit.Hearts] < 4;
+                        };
                     }
                     else
                     {
@@ -293,6 +343,17 @@ namespace Trickster.Bots
                         response.BidPointType = BidPointType.Hcp;
                         response.BidMessage = BidMessage.Signoff;
                         response.IsBalanced = true;
+                        //  also use this bid when we're not balanced if nothing else fits
+                        response.AlternateMatches = hand =>
+                        {
+                            var hcp = BasicBidding.ComputeHighCardPoints(hand);
+                            var counts = BasicBidding.CountsBySuit(hand);
+                            return !BasicBidding.IsBalanced(hand)
+                                && hcp >= 13
+                                && hcp <= 15
+                                && counts[Suit.Spades] < 4
+                                && counts[Suit.Hearts] < 4;
+                        };
                     }
 
                     break;


### PR DESCRIPTION
Used as a fallback if nothing else fits to avoid passing when HCP suggests we should be playing at a higher level.