### PR TITLE
Bridge: Fix responses to pre-empts

### DIFF
--- a/TestBots/Bridge/SAYC/Response.pbn
+++ b/TestBots/Bridge/SAYC/Response.pbn
@@ -16,3 +16,23 @@ Pass 1NT Pass 3NT
 [Auction "W"]
 Pass 1D Pass 1S
 Pass 1NT
+
+[Event "Respond to a pre-empt without support below game"]
+[Deal "S:- - .K643.AJT93.J976 -"]
+[Auction "S"]
+2S Pass 3D Pass
+
+[Event "Respond to a pre-empt without support above game"]
+[Deal "S:- - .K643.AJT93.J976 -"]
+[Auction "S"]
+4S Pass Pass Pass
+
+[Event "Respond to a pre-empt with support below game"]
+[Deal "S:- - .K64.AJT93.J9763 -"]
+[Auction "S"]
+2H Pass 3H Pass
+
+[Event "Respond to a pre-empt with support above game"]
+[Deal "S:- - .K64.AJT93.J9763 -"]
+[Auction "S"]
+4H Pass Pass Pass

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 10/8/2024 1:14 PM (-05:00)
+// last updated 10/23/2024 11:13 AM (-05:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -561,7 +561,7 @@ namespace TestBots
                     new SaycResult(false, 432, 428), // last run result: 3♥; expected: 3NT;
                     new SaycResult(false, 432, 428), // last run result: 3♥; expected: 3NT;
                     new SaycResult(false, -2, 428), // last run result: Pass; expected: 3NT;
-                    new SaycResult(false, 429, 420), // last run result: 3♣; expected: 2NT;
+                    new SaycResult(false, 432, 420), // last run result: 3♥; expected: 2NT;
                     new SaycResult(true, 439, 439),
                     new SaycResult(true, 439, 439),
                     new SaycResult(true, 439, 439),
@@ -571,7 +571,7 @@ namespace TestBots
                     new SaycResult(false, 416, 440), // last run result: 1♥; expected: 4♥;
                     new SaycResult(false, 432, 440), // last run result: 3♥; expected: 4♥;
                     new SaycResult(false, -2, 440), // last run result: Pass; expected: 4♥;
-                    new SaycResult(false, 446, 445), // last run result: 5♦; expected: 5♣;
+                    new SaycResult(false, -2, 445), // last run result: Pass; expected: 5♣;
                     new SaycResult(false, -2, 402), // last run result: Pass; expected: X;
                     new SaycResult(false, 415, 423), // last run result: 1♠; expected: 2♠;
                 }
@@ -870,7 +870,7 @@ namespace TestBots
                     new SaycResult(false, 402, 424), // last run result: X; expected: 2♥;
                     new SaycResult(true, 402, 402),
                     new SaycResult(true, 422, 422),
-                    new SaycResult(false, 421, 432), // last run result: 2♣; expected: 3♥;
+                    new SaycResult(true, 432, 432),
                     new SaycResult(false, -2, 432), // last run result: Pass; expected: 3♥;
                     new SaycResult(true, 402, 402),
                     new SaycResult(true, 423, 423),
@@ -978,7 +978,7 @@ namespace TestBots
                     new SaycResult(true, 415, 415),
                     new SaycResult(true, -2, -2),
                     new SaycResult(true, 440, 440),
-                    new SaycResult(true, 422, 422),
+                    new SaycResult(false, 424, 422), // last run result: 2♥; expected: 2♦;
                     new SaycResult(true, -2, -2),
                     new SaycResult(false, 412, 421), // last run result: 1NT; expected: 2♣;
                     new SaycResult(true, 428, 428),
@@ -997,7 +997,7 @@ namespace TestBots
                     new SaycResult(true, -2, -2),
                     new SaycResult(false, 429, -2), // last run result: 3♣; expected: Pass;
                     new SaycResult(false, -2, 422), // last run result: Pass; expected: 2♦;
-                    new SaycResult(false, 422, 421), // last run result: 2♦; expected: 2♣;
+                    new SaycResult(true, 421, 421),
                     new SaycResult(true, -2, -2),
                     new SaycResult(true, -2, -2),
                     new SaycResult(true, 415, 415),
@@ -1072,7 +1072,7 @@ namespace TestBots
                     new SaycResult(false, -2, 439), // last run result: Pass; expected: 4♠;
                     new SaycResult(true, 424, 424),
                     new SaycResult(true, -2, -2),
-                    new SaycResult(false, 453, 439), // last run result: 6♣; expected: 4♠;
+                    new SaycResult(false, 463, 439), // last run result: 7♠; expected: 4♠;
                     new SaycResult(false, 428, 440), // last run result: 3NT; expected: 4♥;
                     new SaycResult(false, -2, 432), // last run result: Pass; expected: 3♥;
                     new SaycResult(false, -2, 421), // last run result: Pass; expected: 2♣;
@@ -1118,7 +1118,7 @@ namespace TestBots
                     new SaycResult(true, -2, -2),
                     new SaycResult(true, -2, -2),
                     new SaycResult(false, 420, 429), // last run result: 2NT; expected: 3♣;
-                    new SaycResult(false, 422, -2), // last run result: 2♦; expected: Pass;
+                    new SaycResult(false, 423, -2), // last run result: 2♠; expected: Pass;
                     new SaycResult(false, -2, 402), // last run result: Pass; expected: X;
                     new SaycResult(false, -2, 402), // last run result: Pass; expected: X;
                     new SaycResult(true, 420, 420),

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -170,7 +170,7 @@ namespace Trickster.Bots
             {
                 suggestions = suggestions
                     .OrderByDescending(s => s.why.Priority)
-                    .ThenBy(s => s.why.HandShape.Any(hs => IsMajor(hs.Key) && hs.Value.Min > 3) ? 0 : 1)
+                    .ThenBy(s => s.why.HandShape.Any(hs => IsMajor(hs.Key) && hs.Value.Min >= 3) ? 0 : 1)
                     .ThenByDescending(s => s.why.HandShape.Max(hs => hs.Value.Min))
                     .ThenByDescending(s => s.why.Points.Min);
             }

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
@@ -729,9 +729,10 @@ namespace Trickster.Bots
             }
             else if (response.declareBid.suit == opening.declareBid.suit)
             {
-                if (response.declareBid.level == opening.declareBid.level + 1)
+                if (response.declareBid.level == opening.declareBid.level + 1 && response.declareBid.level <= response.GameLevel)
                 {
                     //  simple raise with 3+ support
+                    response.BidMessage = BidMessage.Signoff;
                     response.HandShape[response.declareBid.suit].Min = 3;
                     response.Description = $"3+ {response.declareBid.suit}";
                 }
@@ -743,9 +744,9 @@ namespace Trickster.Bots
                     response.Description = $"4+ {response.declareBid.suit}";
                 }
             }
-            else
+            else if (response.declareBid.level < response.GameLevel)
             {
-                //  new suit
+                //  new suit below the game level
                 response.BidMessage = BidMessage.Forcing;
                 response.HandShape[response.declareBid.suit].Min = 5;
                 response.IsGood = true;


### PR DESCRIPTION
Now properly constrained to the game level.

Also fixed an edge case where the bot failed to prioritize supporting a major with 3-card support.