### PR TITLE
Bridge: Fix Jacoby 2NT

### DIFF
--- a/TestBots/Bridge/SAYC/Jacoby 2NT.pbn
+++ b/TestBots/Bridge/SAYC/Jacoby 2NT.pbn
@@ -1,0 +1,47 @@
+[Event "Response to Jacoby 2NT after 1S (minimum, not short)"]
+[Deal "N:AKQJ3.Q75.T86.83 - - -"]
+[Auction "N"]
+1S Pass 2NT Pass
+4S
+
+[Event "Response to Jacoby 2NT after 1H (minimum, not short)"]
+[Deal "N:Q75.AKQJ3.T86.83 - - -"]
+[Auction "N"]
+1H Pass 2NT Pass
+4H
+
+[Event "Response to Jacoby 2NT after 1S (medium, not short)"]
+[Deal "N:AKQJ3.A75.T86.83 - - -"]
+[Auction "N"]
+1S Pass 2NT Pass
+3NT
+
+[Event "Response to Jacoby 2NT after 1H (medium, not short)"]
+[Deal "N:A75.AKQJ3.T86.83 - - -"]
+[Auction "N"]
+1H Pass 2NT Pass
+3NT
+
+[Event "Response to Jacoby 2NT after 1S (maximum, not short)"]
+[Deal "N:AKQJ3.A7.K865.83 - - -"]
+[Auction "N"]
+1S Pass 2NT Pass
+3S
+
+[Event "Response to Jacoby 2NT after 1H (maximum, not short)"]
+[Deal "N:A7.AKQJ3.K865.83 - - -"]
+[Auction "N"]
+1H Pass 2NT Pass
+3H
+
+[Event "Response to Jacoby 2NT after 1S (singleton)"]
+[Deal "N:AKQJ3.A.AK86.876 - - -"]
+[Auction "N"]
+1S Pass 2NT Pass
+3H
+
+[Event "Response to Jacoby 2NT after 1S (good 5-card side suit)"]
+[Deal "N:AKQJ3.A7.AK865.8 - - -"]
+[Auction "N"]
+1S Pass 2NT Pass
+4D

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 12/19/2024 1:53 PM (-06:00)
+// last updated 12/23/2024 1:10 PM (-06:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -237,14 +237,14 @@ namespace TestBots
                 "test_jacoby_two_nt_response_to_one_of_a_major", new[]
                 {
                     new SaycResult(true, 420, 420),
-                    new SaycResult(false, 431, 438), // last run result: 3♠; expected: 4♦;
-                    new SaycResult(false, 431, 432), // last run result: 3♠; expected: 3♥;
+                    new SaycResult(true, 438, 438),
+                    new SaycResult(false, 438, 432), // last run result: 4♦; expected: 3♥;
                     new SaycResult(true, 440, 440),
                     new SaycResult(true, 429, 429),
                     new SaycResult(true, 432, 432),
                     new SaycResult(true, 428, 428),
-                    new SaycResult(false, 429, 438), // last run result: 3♣; expected: 4♦;
-                    new SaycResult(false, 429, 438), // last run result: 3♣; expected: 4♦;
+                    new SaycResult(true, 438, 438),
+                    new SaycResult(true, 438, 438),
                     new SaycResult(false, 428, 420), // last run result: 3NT; expected: 2NT;
                     new SaycResult(false, 428, 420), // last run result: 3NT; expected: 2NT;
                     new SaycResult(true, 421, 421),
@@ -1072,7 +1072,7 @@ namespace TestBots
                     new SaycResult(false, -2, 439), // last run result: Pass; expected: 4♠;
                     new SaycResult(true, 424, 424),
                     new SaycResult(true, -2, -2),
-                    new SaycResult(false, 463, 439), // last run result: 7♠; expected: 4♠;
+                    new SaycResult(false, 455, 439), // last run result: 6♠; expected: 4♠;
                     new SaycResult(false, 428, 440), // last run result: 3NT; expected: 4♥;
                     new SaycResult(false, 429, 432), // last run result: 3♣; expected: 3♥;
                     new SaycResult(false, -2, 421), // last run result: Pass; expected: 2♣;

--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -137,6 +137,9 @@
     <Content Include="Bridge\SAYC\Opener Rebid.pbn">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Bridge\SAYC\Jacoby 2NT.pbn">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -161,7 +161,7 @@ namespace Trickster.Bots
                 //  when opening, prefer suggestions with higher minimum points first, then higher minimum cards
             {
                 suggestions = suggestions
-                    .OrderByDescending(s => s.why.Priority)
+                    .OrderBy(s => s.why.Priority)
                     .ThenByDescending(s => s.why.Points.Min)
                     .ThenByDescending(s => s.why.HandShape.Max(hs => hs.Value.Min));
             }
@@ -169,7 +169,7 @@ namespace Trickster.Bots
                 //  in other phases, prefer finding the best fit first (prioritizing majors), then higher minimum points
             {
                 suggestions = suggestions
-                    .OrderByDescending(s => s.why.Priority)
+                    .OrderBy(s => s.why.Priority)
                     .ThenBy(s => s.why.HandShape.Any(hs => IsMajor(hs.Key) && hs.Value.Min >= 3) ? 0 : 1)
                     .ThenByDescending(s => s.why.HandShape.Max(hs => hs.Value.Min))
                     .ThenByDescending(s => s.why.Points.Min);

--- a/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
@@ -34,7 +34,7 @@ namespace Trickster.Bots
 
         public string AlternatePoints = string.Empty;
 
-        public int Priority = 0;
+        public int Priority = 100;
 
         public InterpretedBid()
         {

--- a/TricksterBots/Bots/Bridge/bridgebid/conventions/Jacoby2NT.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/conventions/Jacoby2NT.cs
@@ -8,7 +8,8 @@ namespace Trickster.Bots
         {
             if (bid.bidIsDeclare && bid.Index >= 2 && bid.History[bid.Index - 2].BidConvention == BidConvention.Jacoby2NT)
             {
-                Answer(bid);
+                var opening = bid.History[bid.Index - 4];
+                Answer(opening, bid);
                 return true;
             }
 
@@ -18,53 +19,78 @@ namespace Trickster.Bots
         //  If responder jumps to 2NT over a 1H or 1S opening, that is Jacoby 2NT, asking
         //  opener to show a singleton or void. If opener has no short suit, he shows his
         //  hand strength;
-        private static void Answer(InterpretedBid answer)
+        private static void Answer(InterpretedBid opening, InterpretedBid answer)
         {
             if (answer.declareBid.level == 3)
             {
-                if (answer.declareBid.suit == Suit.Hearts)
+                if (answer.declareBid.suit == opening.declareBid.suit)
                 {
-                    //  3H = maximum hand (18+)
+                    //  maximum hand (18+)
+                    //  1H-2N-3H
+                    //  1S-2N-2S
                     answer.Points.Min = 18;
                     answer.BidConvention = BidConvention.AnswerJacoby2NT;
                     foreach (var s in SuitRank.stdSuits) answer.HandShape[s].Min = 2;
+                    answer.HandShape[opening.declareBid.suit].Min = 5;
                     answer.Description = "maximum hand; no short suit";
+                    answer.Priority = 5;
                 }
                 else if (answer.declareBid.suit == Suit.Unknown)
                 {
-                    //  3N = medium hand (15–17)
+                    //  medium hand (15–17)
+                    //  1H-2N-3N
+                    //  1S-2N-3N
                     answer.Points.Min = 15;
                     answer.Points.Max = 17;
                     answer.BidConvention = BidConvention.AnswerJacoby2NT;
                     foreach (var s in SuitRank.stdSuits) answer.HandShape[s].Min = 2;
+                    answer.HandShape[opening.declareBid.suit].Min = 5;
                     answer.Description = "medium hand; no short suit";
+                    answer.Priority = 3;
                 }
                 else
                 {
-                    //  3C, 3D, 3S = singleton or void in that suit; other bids deny a short suit
+                    //  singleton or void in that suit; other bids deny a short suit
+                    //  1H-2N-3C
+                    //  1H-2N-3D
+                    //  1H-2N-3S
+                    //  1S-2N-3C
+                    //  1S-2N-3D
+                    //  1S-2N-3H
                     answer.BidConvention = BidConvention.AnswerJacoby2NT;
                     answer.HandShape[answer.declareBid.suit].Max = 1;
+                    answer.HandShape[opening.declareBid.suit].Min = 5;
                     answer.Description = $"singleton or void in {answer.declareBid.suit}";
+                    answer.Priority = 2;
                 }
             }
             else if (answer.declareBid.level == 4)
             {
-                if (answer.declareBid.suit == Suit.Hearts)
+                if (answer.declareBid.suit == opening.declareBid.suit)
                 {
-                    //  4H = minimum hand
+                    //  minimum hand
+                    //  1H-2N-4H
+                    //  1S-2N-4S
                     answer.Points.Min = 13;
                     answer.Points.Max = 14;
                     answer.BidConvention = BidConvention.AnswerJacoby2NT;
                     foreach (var s in SuitRank.stdSuits) answer.HandShape[s].Min = 2;
+                    answer.HandShape[opening.declareBid.suit].Min = 5;
                     answer.Description = "minimum hand; no short suit";
+                    answer.Priority = 4;
                 }
                 else if (BridgeBot.IsMinor(answer.declareBid.suit))
                 {
-                    //  4C, 4D = 2nd suit
+                    //  2nd suit
+                    //  1H-2N-4C
+                    //  1H-2N-4D
+                    //  1S-2N-4C
+                    //  1S-2N-4D
                     answer.BidConvention = BidConvention.AnswerJacoby2NT;
                     answer.HandShape[answer.declareBid.suit].Min = 5;
-                    foreach (var s in SuitRank.stdSuits) answer.HandShape[s].Min = 2;
-                    answer.Description = $"5+ {answer.declareBid.suit}; no short suit";
+                    answer.HandShape[opening.declareBid.suit].Min = 5;
+                    answer.Description = $"5+ {answer.declareBid.suit}";
+                    answer.Priority = 1;
                 }
             }
         }

--- a/TricksterBots/Bots/Bridge/bridgebid/conventions/Jacoby2NT.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/conventions/Jacoby2NT.cs
@@ -27,7 +27,7 @@ namespace Trickster.Bots
                 {
                     //  maximum hand (18+)
                     //  1H-2N-3H
-                    //  1S-2N-2S
+                    //  1S-2N-3S
                     answer.Points.Min = 18;
                     answer.BidConvention = BidConvention.AnswerJacoby2NT;
                     foreach (var s in SuitRank.stdSuits) answer.HandShape[s].Min = 2;

--- a/TricksterBots/Bots/Bridge/bridgebid/conventions/Stayman.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/conventions/Stayman.cs
@@ -212,7 +212,7 @@ namespace Trickster.Bots
             response.BidMessage = BidMessage.Forcing;
             response.Points.Min = response.declareBid.level == 1 ? 8 : response.declareBid.level == 2 ? 4 : 0;
             response.Description = "asking for a major";
-            response.Priority = 100; // always prefer Stayman over other bids when valid
+            response.Priority = 1; // always prefer Stayman over other bids when valid
             response.Validate = hand =>
             {
                 //  we should have 4H or 4S (any more and we'll use a transfer instead)

--- a/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/phases/Response.cs
@@ -466,12 +466,16 @@ namespace Trickster.Bots
                         //  1H-2N
                         //  1S-2N
                         case Suit.Unknown:
-                            response.Points.Min = 13;
-                            response.BidPointType = BidPointType.Dummy;
-                            response.BidConvention = BidConvention.Jacoby2NT;
-                            response.BidMessage = BidMessage.Forcing;
-                            response.HandShape[opening.declareBid.suit].Min = 4;
-                            response.Description = $"4+ {opening.declareBid.suit}";
+                            if (overcall.bid == BidBase.Pass)
+                            {
+                                response.Points.Min = 13;
+                                response.BidPointType = BidPointType.Dummy;
+                                response.BidConvention = BidConvention.Jacoby2NT;
+                                response.BidMessage = BidMessage.Forcing;
+                                response.HandShape[opening.declareBid.suit].Min = 4;
+                                response.Description = $"4+ {opening.declareBid.suit}";
+                            }
+                            //  TODO: should we include an alternate meaning for 2NT after interference?
                             break;
                     }
 


### PR DESCRIPTION
Corrects opener rebids to relate to the opening suit and incorporates relative priority when choosing between overlapping bids.

Also disables the convention if there's interference before responder bids.