### PR TITLE
Bridge: Bid if too strong but nothing else matches

### DIFF
--- a/TestBots/Bridge/SAYC/Response.pbn
+++ b/TestBots/Bridge/SAYC/Response.pbn
@@ -43,3 +43,8 @@ Pass 1NT
 Pass Pass 1H Pass
 2C Pass 3NT Pass
 4H Pass Pass Pass
+
+[Event "Respond to minor with gap strength (too strong for 1NT; too weak for 2NT)"]
+[Deal "E:- - - QT5.T87.QJ4.AQ93"]
+[Auction "E"]
+Pass 1C Pass 1NT

--- a/TestBots/Bridge/Test_Sayc.cs
+++ b/TestBots/Bridge/Test_Sayc.cs
@@ -576,7 +576,7 @@ namespace TestBots
                     new[] { "KQ.AJT.K87.A9876", "4H", "1S P 2H P" }, // p54, h18
                     new[] { "K5.AJ9.AKJ984.A9", "4H", "1H P 1N P" }, // p54, h19 (Maybe 3H?)
                     new[] { "K765.AK87.KQ.A98", "2N", "1D P 1H P" }, // p54, h20
-                    new[] { "K4.AKQJ94.87.A96", "3N", "1D P 1H P" }, // p54, h21
+                    new[] { "K4.AKQJ94.87.A96", "3D", "1D P 1H P" }, // p54, h21 (conservative 3D or gambling 3NT)
 
                     // JumpShift is forcing and thus better than rebidding to show 6 hearts.
                     new[] { "AKJ5.Q2.AQ9842.A", "3C", "P 1H P 1S P" }, // 8-7855840deedca11a0d32bf79b8, N

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 12/23/2024 1:10 PM (-06:00)
+// last updated 2/10/2025 2:08 PM (-06:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -276,22 +276,22 @@ namespace TestBots
                     new SaycResult(true, 416, 416),
                     new SaycResult(true, -2, -2),
                     new SaycResult(true, -2, -2),
-                    new SaycResult(false, -2, 445), // last run result: Pass; expected: 5♣;
+                    new SaycResult(false, 429, 445), // last run result: 3♣; expected: 5♣;
                 }
              },
              {
                 "test_invitational_response_to_one_of_a_minor", new[]
                 {
                     new SaycResult(true, 415, 415),
-                    new SaycResult(false, -2, 412), // last run result: Pass; expected: 1NT;
+                    new SaycResult(false, 422, 412), // last run result: 2♦; expected: 1NT;
                     new SaycResult(true, 414, 414),
                     new SaycResult(true, 422, 422),
                     new SaycResult(true, 429, 429),
                     new SaycResult(true, 421, 421),
                     new SaycResult(false, 416, 422), // last run result: 1♥; expected: 2♦;
                     new SaycResult(false, 445, 428), // last run result: 5♣; expected: 3NT;
-                    new SaycResult(false, -2, 412), // last run result: Pass; expected: 1NT;
-                    new SaycResult(false, -2, 430), // last run result: Pass; expected: 3♦;
+                    new SaycResult(true, 412, 412),
+                    new SaycResult(false, 422, 430), // last run result: 2♦; expected: 3♦;
                 }
              },
              {
@@ -305,10 +305,10 @@ namespace TestBots
                     new SaycResult(true, 416, 416),
                     new SaycResult(true, 428, 428),
                     new SaycResult(true, 428, 428),
-                    new SaycResult(false, -2, 428), // last run result: Pass; expected: 3NT;
-                    new SaycResult(false, -2, 437), // last run result: Pass; expected: 4♣;
-                    new SaycResult(false, -2, 438), // last run result: Pass; expected: 4♦;
-                    new SaycResult(false, -2, 437), // last run result: Pass; expected: 4♣;
+                    new SaycResult(true, 428, 428),
+                    new SaycResult(false, 429, 437), // last run result: 3♣; expected: 4♣;
+                    new SaycResult(false, 430, 438), // last run result: 3♦; expected: 4♦;
+                    new SaycResult(false, 429, 437), // last run result: 3♣; expected: 4♣;
                     new SaycResult(false, 429, 421), // last run result: 3♣; expected: 2♣;
                     new SaycResult(true, 421, 421),
                 }
@@ -367,12 +367,12 @@ namespace TestBots
                     new SaycResult(false, 428, 440), // last run result: 3NT; expected: 4♥;
                     new SaycResult(false, -2, 440), // last run result: Pass; expected: 4♥;
                     new SaycResult(false, 429, 420), // last run result: 3♣; expected: 2NT;
-                    new SaycResult(false, 412, 428), // last run result: 1NT; expected: 3NT;
-                    new SaycResult(false, 412, 429), // last run result: 1NT; expected: 3♣;
+                    new SaycResult(true, 430, 430),
+                    new SaycResult(true, 429, 429),
                     new SaycResult(false, 440, 438), // last run result: 4♥; expected: 4♦;
                     new SaycResult(false, -2, 432), // last run result: Pass; expected: 3♥;
                     new SaycResult(false, 420, 428), // last run result: 2NT; expected: 3NT;
-                    new SaycResult(false, 412, 430), // last run result: 1NT; expected: 3♦;
+                    new SaycResult(false, 422, 430), // last run result: 2♦; expected: 3♦;
                     new SaycResult(false, 439, 440), // last run result: 4♠; expected: 4♥;
                 }
              },
@@ -459,7 +459,7 @@ namespace TestBots
                     new SaycResult(false, 430, 415), // last run result: 3♦; expected: 1♠;
                     new SaycResult(false, 424, 428), // last run result: 2♥; expected: 3NT;
                     new SaycResult(false, -2, 439), // last run result: Pass; expected: 4♠;
-                    new SaycResult(false, 420, 424), // last run result: 2NT; expected: 2♥;
+                    new SaycResult(false, 432, 424), // last run result: 3♥; expected: 2♥;
                     new SaycResult(false, 423, 430), // last run result: 2♠; expected: 3♦;
                 }
              },
@@ -853,7 +853,7 @@ namespace TestBots
                     new SaycResult(true, -2, -2),
                     new SaycResult(true, 428, 428),
                     new SaycResult(false, 421, 420), // last run result: 2♣; expected: 2NT;
-                    new SaycResult(false, 412, 428), // last run result: 1NT; expected: 3NT;
+                    new SaycResult(false, 420, 428), // last run result: 2NT; expected: 3NT;
                     new SaycResult(false, 424, 423), // last run result: 2♥; expected: 2♠;
                     new SaycResult(false, 412, 424), // last run result: 1NT; expected: 2♥;
                     new SaycResult(false, 423, 424), // last run result: 2♠; expected: 2♥;
@@ -871,7 +871,7 @@ namespace TestBots
                     new SaycResult(true, 402, 402),
                     new SaycResult(true, 422, 422),
                     new SaycResult(true, 432, 432),
-                    new SaycResult(false, -2, 432), // last run result: Pass; expected: 3♥;
+                    new SaycResult(true, 432, 432),
                     new SaycResult(true, 402, 402),
                     new SaycResult(true, 423, 423),
                     new SaycResult(false, -2, 424), // last run result: Pass; expected: 2♥;
@@ -969,7 +969,7 @@ namespace TestBots
                     new SaycResult(true, 428, 428),
                     new SaycResult(false, 428, 421), // last run result: 3NT; expected: 2♣;
                     new SaycResult(false, -2, 428), // last run result: Pass; expected: 3NT;
-                    new SaycResult(false, 412, 428), // last run result: 1NT; expected: 3NT;
+                    new SaycResult(false, 429, 428), // last run result: 3♣; expected: 3NT;
                     new SaycResult(false, 421, -2), // last run result: 2♣; expected: Pass;
                     new SaycResult(true, -2, -2),
                     new SaycResult(true, 440, 440),
@@ -1003,7 +1003,7 @@ namespace TestBots
                     new SaycResult(true, 415, 415),
                     new SaycResult(true, 415, 415),
                     new SaycResult(true, -2, -2),
-                    new SaycResult(false, 420, 452), // last run result: 2NT; expected: 6NT;
+                    new SaycResult(false, 438, 452), // last run result: 4♦; expected: 6NT;
                     new SaycResult(false, 424, 412), // last run result: 2♥; expected: 1NT;
                     new SaycResult(false, 415, 402), // last run result: 1♠; expected: X;
                     new SaycResult(true, 439, 439),
@@ -1082,7 +1082,7 @@ namespace TestBots
                     new SaycResult(true, 412, 412),
                     new SaycResult(false, -2, 420), // last run result: Pass; expected: 2NT;
                     new SaycResult(false, -2, 428), // last run result: Pass; expected: 3NT;
-                    new SaycResult(false, -2, 428), // last run result: Pass; expected: 3NT;
+                    new SaycResult(true, 428, 428),
                     new SaycResult(false, -2, 446), // last run result: Pass; expected: 5♦;
                     new SaycResult(false, 423, 420), // last run result: 2♠; expected: 2NT;
                     new SaycResult(false, -2, 402), // last run result: Pass; expected: X;
@@ -1091,7 +1091,7 @@ namespace TestBots
                     new SaycResult(true, -2, -2),
                     new SaycResult(false, 440, 432), // last run result: 4♥; expected: 3♥;
                     new SaycResult(false, 430, 422), // last run result: 3♦; expected: 2♦;
-                    new SaycResult(false, 420, 432), // last run result: 2NT; expected: 3♥;
+                    new SaycResult(true, 432, 432),
                     new SaycResult(true, -2, -2),
                     new SaycResult(true, -2, -2),
                     new SaycResult(false, -2, 440), // last run result: Pass; expected: 4♥;

--- a/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
@@ -184,7 +184,7 @@ namespace Trickster.Bots
             return 1;
         }
 
-        public bool Match(Hand hand)
+        public bool Match(Hand hand, bool allowTooStrong = false)
         {
             if (AlternateMatches != null && AlternateMatches(hand))
                 return true;
@@ -210,7 +210,7 @@ namespace Trickster.Bots
                     throw new Exception("Unknown point type");
             }
 
-            if (Points.Min > points || points > Points.Max)
+            if (Points.Min > points || (points > Points.Max && !allowTooStrong))
                 return false;
 
             var counts = BasicBidding.CountsBySuit(hand);


### PR DESCRIPTION
Fix #167 

Previously if no bids matched because the hand was too strong for any of them (and didn't fit the shape of others) the bot would pass unless partner's bid was forcing.

This change uncaps bids when this situation is hit allowing the bot to make a bid it was otherwise too strong for (which is at least better than passing, if not always optimal).