### PR TITLE
Bridge: Takeout double is "off" after 4D

### DIFF
--- a/TestBots/Bridge/SAYC/Overcalls.pbn
+++ b/TestBots/Bridge/SAYC/Overcalls.pbn
@@ -30,3 +30,11 @@ Pass 2S
 [Auction "S"]
 4S Pass Pass X
 Pass Pass Pass
+
+[Event "Bid best suit when advancing a takeout double"]
+[Dealer "S"]
+[Vulnerable "None"]
+[Deal "S:- 95.Q.A97654.J764 - -"]
+[Auction "S"]
+3S Pass Pass X
+4D Pass Pass

--- a/TestBots/Bridge/SAYC/Overcalls.pbn
+++ b/TestBots/Bridge/SAYC/Overcalls.pbn
@@ -22,3 +22,11 @@ Pass
 [Auction "W"]
 1H Pass Pass 2H
 Pass 2S
+
+[Event "Double of game bid is for penalty, not takeout"]
+[Dealer "S"]
+[Vulnerable "None"]
+[Deal "S:- 95.Q.A97654.J764 - -"]
+[Auction "S"]
+4S Pass Pass X
+Pass Pass Pass

--- a/TestBots/Bridge/SAYC/Overcalls.pbn
+++ b/TestBots/Bridge/SAYC/Overcalls.pbn
@@ -29,7 +29,7 @@ Pass 2S
 [Deal "S:- 95.Q.A97654.J764 - -"]
 [Auction "S"]
 4S Pass Pass X
-Pass Pass Pass
+Pass Pass
 
 [Event "Bid best suit when advancing a takeout double"]
 [Dealer "S"]
@@ -37,4 +37,36 @@ Pass Pass Pass
 [Deal "S:- 95.Q.A97654.J764 - -"]
 [Auction "S"]
 3S Pass Pass X
-4D Pass Pass
+Pass 4D
+
+[Event "Double of 4C is a takeout double"]
+[Dealer "S"]
+[Vulnerable "None"]
+[Deal "S:- 95.Q.A97654.J764 - -"]
+[Auction "S"]
+4C Pass Pass X
+Pass 4D
+
+[Event "Double of 4D is a takeout double"]
+[Dealer "S"]
+[Vulnerable "None"]
+[Deal "S:- 95.A97654.Q.J764 - -"]
+[Auction "S"]
+4D Pass Pass X
+Pass 4H
+
+[Event "Double of 4H is for penalty, not takeout"]
+[Dealer "S"]
+[Vulnerable "None"]
+[Deal "S:- 95.Q.A97654.J764 - -"]
+[Auction "S"]
+4H Pass Pass X
+Pass Pass
+
+[Event "Takeout double avoiding two suits"]
+[Dealer "S"]
+[Vulnerable "None"]
+[Deal "S:- A643.86325..K832 - -"]
+[Auction "S"]
+1S Pass 2H X
+Pass 3C

--- a/TricksterBots/Bots/Bridge/bridgebid/conventions/TakeoutDouble.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/conventions/TakeoutDouble.cs
@@ -27,6 +27,7 @@ namespace Trickster.Bots
 
             if (bid.BidPhase == BidPhase.Response && bid.History[bid.Index - 1].BidConvention == BidConvention.TakeoutDouble)
                 return Response(bid.History[bid.Index - 2], bid);
+
             if (bid.Index >= 2 && bid.History[bid.Index - 2].BidConvention == BidConvention.TakeoutDouble)
             {
                 Advance(bid);
@@ -141,7 +142,7 @@ namespace Trickster.Bots
         private static bool Overcall(InterpretedBid opening, InterpretedBid response, InterpretedBid overcall)
         {
             //  a double is for takeout over an opening partscore bid (4D or lower)
-            if (overcall.LowestAvailableLevel(Suit.Hearts) > 4)
+            if (overcall.LowestAvailableLevel(Suit.Hearts, true) >= 4)
                 return false;
 
             var bidSuits = SuitRank.stdSuits.Where(s =>

--- a/TricksterBots/Bots/Bridge/bridgebid/conventions/TakeoutDouble.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/conventions/TakeoutDouble.cs
@@ -52,7 +52,6 @@ namespace Trickster.Bots
             if (!advance.bidIsDeclare)
                 return;
 
-            //  TODO: consider passing if RHO bid
             var opening = advance.History.First(b => b.bid != BidBase.Pass);
             var lowestAvailableLevel = advance.LowestAvailableLevel(advance.declareBid.suit);
 
@@ -64,24 +63,24 @@ namespace Trickster.Bots
                     advance.IsBalanced = true;
                     advance.Description = $"stopper in {opening.declareBid.suit}";
                     advance.Validate = hand => BasicBidding.HasStopper(hand, opening.declareBid.suit);
-                }
 
-                if (advance.declareBid.level == lowestAvailableLevel)
-                {
-                    //  6-10 points: bid notrump at the cheapest level
-                    advance.Points.Min = 6;
-                    advance.Points.Max = 10;
-                }
-                else if (advance.declareBid.level == lowestAvailableLevel + 1)
-                {
-                    //  11-12 points: bid notrump, jumping a level
-                    advance.Points.Min = 11;
-                    advance.Points.Max = 12;
-                }
-                else if (advance.declareBid.level == 3)
-                {
-                    //  13+ points: bid game in notrump
-                    advance.Points.Min = 13;
+                    if (advance.declareBid.level == lowestAvailableLevel)
+                    {
+                        //  6-10 points: bid notrump at the cheapest level
+                        advance.Points.Min = 6;
+                        advance.Points.Max = 10;
+                    }
+                    else if (advance.declareBid.level == lowestAvailableLevel + 1)
+                    {
+                        //  11-12 points: bid notrump, jumping a level
+                        advance.Points.Min = 11;
+                        advance.Points.Max = 12;
+                    }
+                    else if (advance.declareBid.level == 3)
+                    {
+                        //  13+ points: bid game in notrump
+                        advance.Points.Min = 13;
+                    }
                 }
                 else if (advance.declareBid.level == 4)
                 {
@@ -94,6 +93,7 @@ namespace Trickster.Bots
             else
             {
                 var gameLevel = BridgeBot.IsMajor(advance.declareBid.suit) ? 4 : 5;
+                var bidSuits = advance.History.Where(b => b.bidIsDeclare).Select(b => b.declareBid.suit).Distinct().ToList();
 
                 if (advance.declareBid.suit == opening.declareBid.suit)
                 {
@@ -104,45 +104,58 @@ namespace Trickster.Bots
                     advance.Description = "asking for more information";
                     advance.Validate = hand => false;
                 }
-                else if (advance.declareBid.level == lowestAvailableLevel && advance.declareBid.level <= 2)
+                else if (!bidSuits.Contains(advance.declareBid.suit))
                 {
-                    //  0-8 points: bid at the cheapest level
-                    advance.Points.Max = 8;
-                    advance.HandShape[advance.declareBid.suit].Min = 4;
-                    advance.Description = $"4+ {advance.declareBid.suit}";
-                }
-                else if (advance.declareBid.level == lowestAvailableLevel + 1 && advance.declareBid.level <= 3)
-                {
-                    //  9-11 points: make an invitational bid by jumping a level
-                    advance.Points.Min = 9;
-                    advance.Points.Max = 11;
-                    advance.HandShape[advance.declareBid.suit].Min = 4;
-                    advance.Description = $"4+ {advance.declareBid.suit}; inviting game";
-                }
-                else if (advance.declareBid.level == gameLevel - 1)
-                {
-                    //  4-8 points: make a preemptive bid below game with 6+ cards
-                    advance.Points.Min = 4;
-                    advance.Points.Max = 8;
-                    advance.HandShape[advance.declareBid.suit].Min = 6;
-                    advance.IsPreemptive = true;
-                    advance.Description = $"6+ {advance.declareBid.suit}";
-                }
-                else if (advance.declareBid.level == gameLevel)
-                {
-                    //  12+ points: get the partnership to game
-                    var minCards = BridgeBot.IsMajor(advance.declareBid.suit) ? 4 : 5;
-                    advance.Points.Min = 12;
-                    advance.HandShape[advance.declareBid.suit].Min = minCards;
-                    advance.Description = $"{minCards}+ {advance.declareBid.suit}";
+                    if (advance.declareBid.level == lowestAvailableLevel)
+                    {
+                        //  0-8 points: bid at the cheapest level (but don't cap points if we're at the game level)
+                        if (lowestAvailableLevel < gameLevel)
+                            advance.Points.Max = 8;
+
+                        advance.HandShape[advance.declareBid.suit].Min = 4;
+                        advance.Description = $"4+ {advance.declareBid.suit}";
+                        advance.Validate = hand =>
+                        {
+                            var counts = BasicBidding.CountsBySuit(hand);
+                            var maxCount = counts.Max(kvp => kvp.Value);
+                            return counts[advance.declareBid.suit] == maxCount;
+                        };
+                    }
+                    else if (advance.declareBid.level == lowestAvailableLevel + 1 && advance.declareBid.level <= 3)
+                    {
+                        //  9-11 points: make an invitational bid by jumping a level
+                        advance.Points.Min = 9;
+                        advance.Points.Max = 11;
+                        advance.HandShape[advance.declareBid.suit].Min = 4;
+                        advance.Description = $"4+ {advance.declareBid.suit}; inviting game";
+                    }
+                    else if (advance.declareBid.level == gameLevel - 1)
+                    {
+                        //  4-8 points: make a preemptive bid below game with 6+ cards
+                        advance.Points.Min = 4;
+                        advance.Points.Max = 8;
+                        advance.HandShape[advance.declareBid.suit].Min = 6;
+                        advance.IsPreemptive = true;
+                        advance.Description = $"6+ {advance.declareBid.suit}";
+                    }
+                    else if (advance.declareBid.level == gameLevel)
+                    {
+                        //  12+ points: get the partnership to game
+                        var minCards = BridgeBot.IsMajor(advance.declareBid.suit) ? 4 : 5;
+                        advance.Points.Min = 12;
+                        advance.HandShape[advance.declareBid.suit].Min = minCards;
+                        advance.Description = $"{minCards}+ {advance.declareBid.suit}";
+                    }
                 }
             }
         }
 
         private static bool Overcall(InterpretedBid opening, InterpretedBid response, InterpretedBid overcall)
         {
-            //  a double is for takeout over an opening partscore bid (4D or lower)
-            if (overcall.LowestAvailableLevel(Suit.Hearts, true) >= 4)
+            //  a double is for takeout over 4D or lower
+            var level = response?.declareBid?.level ?? opening.declareBid.level;
+            var suit = response?.declareBid?.suit ?? opening.declareBid.suit;
+            if (BridgeBot.IsMinor(suit) ? level > 4 : level >= 4)
                 return false;
 
             var bidSuits = SuitRank.stdSuits.Where(s =>

--- a/TricksterBots/Bots/Bridge/bridgebid/conventions/TakeoutDouble.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/conventions/TakeoutDouble.cs
@@ -109,7 +109,7 @@ namespace Trickster.Bots
                     if (advance.declareBid.level == lowestAvailableLevel)
                     {
                         //  0-8 points: bid at the cheapest level (but don't cap points if we're at the game level)
-                        if (lowestAvailableLevel < gameLevel)
+                        if (lowestAvailableLevel < gameLevel - 1)
                             advance.Points.Max = 8;
 
                         advance.HandShape[advance.declareBid.suit].Min = 4;
@@ -117,7 +117,7 @@ namespace Trickster.Bots
                         advance.Validate = hand =>
                         {
                             var counts = BasicBidding.CountsBySuit(hand);
-                            var maxCount = counts.Max(kvp => kvp.Value);
+                            var maxCount = counts.Where(kvp => !bidSuits.Contains(kvp.Key)).Max(kvp => kvp.Value);
                             return counts[advance.declareBid.suit] == maxCount;
                         };
                     }


### PR DESCRIPTION
Fix the logic to not interpret a double as a takeout double for anything beyond 4D.

Also fix avoiding advancing in an already bid suit.