### PR TITLE
Bridge: Fix responding to Stayman at higher levels

### DIFF
--- a/TestBots/Bridge/SAYC/2NT Responses.pbn
+++ b/TestBots/Bridge/SAYC/2NT Responses.pbn
@@ -3,3 +3,10 @@
 [Auction "N"]
 Pass Pass 2NT Pass
 Pass Pass
+
+[Event "2NT Response - Stayman"]
+[Deal "S:- - 8654.KQ8.4.KT872 -"]
+[Declarer "S"]
+[Contract "2NT"]
+[Auction "S"]
+2NT Pass 3C

--- a/TestBots/Bridge/Test_Sayc_Results.cs
+++ b/TestBots/Bridge/Test_Sayc_Results.cs
@@ -1,4 +1,4 @@
-// last updated 2/10/2025 2:08 PM (-06:00)
+// last updated 3/24/2025 3:00 PM (-05:00)
 using System.Collections.Generic;
 
 namespace TestBots
@@ -61,7 +61,7 @@ namespace TestBots
              {
                 "test_3c_stayman", new[]
                 {
-                    new SaycResult(false, 428, 429), // last run result: 3NT; expected: 3♣;
+                    new SaycResult(true, 429, 429),
                     new SaycResult(true, 432, 432),
                     new SaycResult(false, 431, 402), // last run result: 3♠; expected: X;
                     new SaycResult(false, 431, 440), // last run result: 3♠; expected: 4♥;

--- a/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
@@ -226,7 +226,8 @@ namespace Trickster.Bots
             var isUnset = !IsBalanced &&
                 Points.Min == 0 && Points.Max == 37 &&
                 HandShape.All(hs => hs.Value.Min == 0 && hs.Value.Max == 13) &&
-                Aces.Count == 0 && Kings.Count == 0;
+                Aces.Count == 0 && Kings.Count == 0 &&
+                Validate == null;
 
             //  don't match bids with "unset" hand-related values (except "Pass")
             if (bid != BidBase.Pass && isUnset)

--- a/TricksterBots/Bots/Bridge/bridgebid/conventions/Stayman.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/conventions/Stayman.cs
@@ -210,7 +210,7 @@ namespace Trickster.Bots
             //  2C-2D-3N-4C
             response.BidConvention = BidConvention.Stayman;
             response.BidMessage = BidMessage.Forcing;
-            response.Points.Min = response.declareBid.level == 1 ? 8 : response.declareBid.level == 2 ? 4 : 0;
+            response.Points.Min = response.declareBid.level <= 2 ? 8 : 4;
             response.Description = "asking for a major";
             response.Priority = 1; // always prefer Stayman over other bids when valid
             response.Validate = hand =>


### PR DESCRIPTION
The level comparisons were off-by-one and resulted in no points being set, which caused the bid values to be treated as unset during the matching routine.

Fixed the level comparisons and point values to match expectations.

Also, fixed the matching routine to respect if there's a validate step.