### PR TITLE
Bridge: Add option to play without transfers

### DIFF
--- a/TestBots/Bridge/BidTest.cs
+++ b/TestBots/Bridge/BidTest.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,12 +38,14 @@ namespace TestBots
             hand = new Hand(test.hand.Replace(" ", string.Empty));
             bidHistory = ParseBasicTestBidHistory(test.history);
             expectedBid = ParseBasicTestBid(test.bid);
+            options = !string.IsNullOrEmpty(test.optionsJson) ? JsonConvert.DeserializeObject<BridgeOptions>(test.optionsJson) : new BridgeOptions();
             type = test.type;
         }
 
         public IReadOnlyList<int> bidHistory { get; set; }
         public int expectedBid { get; set; }
         public Hand hand { get; set; }
+        public BridgeOptions options { get; set; }
         public string type { get; set; } // used only when parsing from JsonTest
         public Vulnerable vulnerable { get; set; } // used only when parsing a Test_Sayc test
 

--- a/TestBots/Bridge/SAYC/1NT Transfers.pbn
+++ b/TestBots/Bridge/SAYC/1NT Transfers.pbn
@@ -4,6 +4,26 @@
 1NT Pass 2H Pass
 2S Pass Pass Pass
 
+[Event "Natural Spades, minimum hand"]
+[GameOptionsJson "{\"noTransfers\":true}"]
+[Deal "N:KT97.KQJ.KQ5.J97 A6.9652.AT6.QT52 J5432.A4.J98.863 Q8.T873.7432.AK4"]
+[Auction "N"]
+1NT Pass 2S Pass
+Pass Pass
+
+[Event "Transfer to Hearts minimum hand"]
+[Deal "N:KQJ.KT97.KQ5.J97 - A4.J5432.J98.863 -"]
+[Auction "N"]
+1NT Pass 2D Pass
+2H Pass Pass Pass
+
+[Event "Natural Hearts, minimum hand"]
+[GameOptionsJson "{\"noTransfers\":true}"]
+[Deal "N:KQJ.KT97.KQ5.J97 - A4.J5432.J98.863 -"]
+[Auction "N"]
+1NT Pass 2H Pass
+Pass Pass
+
 [Event "Transfer to Spades - Invitational, Refused"]
 [Deal "N:KT9.KQJ7.KQ5.J97 5.T983.AJT4.A643 AQ432.654.32.K85 J876.A2.9876.QT2"]
 [Auction "N"]

--- a/TestBots/Bridge/TestBridgeBot.cs
+++ b/TestBots/Bridge/TestBridgeBot.cs
@@ -317,7 +317,8 @@ namespace TestBots
 
         private static string RunBidTest(BidTest test, BridgeBiddingScheme bidding = BridgeBiddingScheme.SAYC)
         {
-            var bot = new BridgeBot(new BridgeOptions { bidding = bidding }, Suit.Unknown);
+            test.options.bidding = bidding;
+            var bot = new BridgeBot(test.options, Suit.Unknown);
             var suggestion = bot.SuggestBid(new BridgeBidHistory(test.bidHistory), test.hand).value;
 
             if (test.expectedBid != suggestion)

--- a/TestBots/PTN.cs
+++ b/TestBots/PTN.cs
@@ -80,6 +80,8 @@ namespace TestBots.Bridge
                         declarerSeat = -1;
                         firstBidderSeat = 0;
                         name = tag.Description;
+                        options = defaultOptions;
+                        optionsJson = string.Empty;
                         break;
                     case "GameOptionsJson":
                         optionsJson = tag.Description;

--- a/TestBots/TestBots.csproj
+++ b/TestBots/TestBots.csproj
@@ -55,8 +55,8 @@
     <ProjectReference Include="..\..\Trickster\TricksterBotClasses\TricksterBotClasses.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'!='Debug'">
-    <Reference Include="TricksterBotClasses, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\TricksterBotClasses.1.7.0\lib\net48\TricksterBotClasses.dll</HintPath>
+    <Reference Include="TricksterBotClasses, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\TricksterBotClasses.1.9.0\lib\net48\TricksterBotClasses.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/TestBots/packages.config
+++ b/TestBots/packages.config
@@ -3,5 +3,5 @@
   <package id="MSTest.TestAdapter" version="2.2.10" targetFramework="net48" />
   <package id="MSTest.TestFramework" version="2.2.10" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
-  <package id="TricksterBotClasses" version="1.7.0" targetFramework="net48" />
+  <package id="TricksterBotClasses" version="1.9.0" targetFramework="net48" />
 </packages>

--- a/TricksterBots/Bots/Bridge/BridgeBot.cs
+++ b/TricksterBots/Bots/Bridge/BridgeBot.cs
@@ -73,10 +73,11 @@ namespace Trickster.Bots
 
         private static Dictionary<int, List<BidBase>> DescribeSaycBidHistoryBySeat(SuggestBidState<BridgeOptions> state)
         {
+            var botOptions = new BridgeBotOptions(state.options);
             var history = new Dictionary<int, List<BidBase>>();
             var dealerSeat = state.dealerSeat;
             var bidHistory = new BridgeBidHistory(state.players, dealerSeat);
-            var interpretedHistory = InterpretedBid.InterpretHistory(bidHistory);
+            var interpretedHistory = InterpretedBid.InterpretHistory(bidHistory, botOptions);
 
             foreach (var player in state.players)
             {
@@ -86,7 +87,7 @@ namespace Trickster.Bots
                 for (var i = 0; i < player.BidHistory.Count; ++i)
                 {
                     var bid = new BidBase(player.BidHistory[i]);
-                    var interpretedBid = new InterpretedBid(bid.value, interpretedHistory, firstIndex + i * 4);
+                    var interpretedBid = new InterpretedBid(bid.value, interpretedHistory, firstIndex + i * 4, botOptions);
 
                     bid.explanation = new BidExplanation(interpretedBid);
 
@@ -111,9 +112,10 @@ namespace Trickster.Bots
 
         private static List<BidBase> DescribeSaycLegalBids(SuggestBidState<BridgeOptions> state)
         {
+            var botOptions = new BridgeBotOptions(state.options);
             var bids = new List<BidBase>();
             var history = new BridgeBidHistory(state.players, state.dealerSeat);
-            var interpretedHistory = InterpretedBid.InterpretHistory(history);
+            var interpretedHistory = InterpretedBid.InterpretHistory(history, botOptions);
 
             foreach (var legalBid in state.legalBids)
             {
@@ -121,7 +123,7 @@ namespace Trickster.Bots
                 var bid = new BidBase(value);
                 if (legalBid.value != BidBase.NoBid)
                 {
-                    var interpretedBid = new InterpretedBid(value, interpretedHistory, interpretedHistory.Count);
+                    var interpretedBid = new InterpretedBid(value, interpretedHistory, interpretedHistory.Count, botOptions);
                     bid.explanation = new BidExplanation(interpretedBid);
                 }
 
@@ -149,11 +151,12 @@ namespace Trickster.Bots
             if (options.bidding == BridgeBiddingScheme.TwoOverOne)
                 return SuggestBridgitBid(history, hand, vulnerable);
 
-            var interpretedHistory = InterpretedBid.InterpretHistory(history);
+            var botOptions = new BridgeBotOptions(options);
+            var interpretedHistory = InterpretedBid.InterpretHistory(history, botOptions);
             var legalBids = AllPossibleBids().Where(history.IsBidLegal).ToList();
 
             foreach (var legalBid in legalBids)
-                legalBid.why = new InterpretedBid(legalBid.value, interpretedHistory, interpretedHistory.Count);
+                legalBid.why = new InterpretedBid(legalBid.value, interpretedHistory, interpretedHistory.Count, botOptions);
 
             //  get and sort all possible suggestions
             var suggestions = legalBids.Where(b => b.why.Match(hand)).ToList();
@@ -464,10 +467,11 @@ namespace Trickster.Bots
 
         private InterpretedBid.PlayerSummary GetPlayerSummary(SuggestCardState<BridgeOptions> state, int playerSeat)
         {
+            var botOptions = new BridgeBotOptions(options);
             var dealerSeat = FindDealerSeat(state);
             var players = new PlayersCollectionBase(this, state.players);
             var history = new BridgeBidHistory(players, dealerSeat);
-            var interpretedHistory = InterpretedBid.InterpretHistory(history);
+            var interpretedHistory = InterpretedBid.InterpretHistory(history, botOptions);
             var firstPlayerBidIndex = (4 + playerSeat - dealerSeat) % 4;
             var nPlayerExtraBids = (interpretedHistory.Count - 1 - firstPlayerBidIndex) / 4;
             var lastPlayerBidIndex = firstPlayerBidIndex + 4 * nPlayerExtraBids;
@@ -643,10 +647,11 @@ namespace Trickster.Bots
             if (options.variation == BridgeVariation.Mini)
                 return new List<Suit>();
 
+            var botOptions = new BridgeBotOptions(options);
             var dealerSeat = FindDealerSeat(state);
             var players = new PlayersCollectionBase(this, state.players);
             var history = new BridgeBidHistory(players, dealerSeat);
-            var interpretedHistory = InterpretedBid.InterpretHistory(history);
+            var interpretedHistory = InterpretedBid.InterpretHistory(history, botOptions);
             var unbidSuits = SuitRank.stdSuits.Where(suit => interpretedHistory.All(b => b.HandShape[suit].Min <= 2));
             return unbidSuits.ToList();
         }

--- a/TricksterBots/Bots/Bridge/bridgebid/BridgeBotOptions.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/BridgeBotOptions.cs
@@ -1,0 +1,14 @@
+using Trickster.cloud;
+
+namespace Trickster.Bots
+{
+    public class BridgeBotOptions
+    {
+        public BridgeBotOptions(BridgeOptions options)
+        {
+            noTransfers = options.noTransfers;
+        }
+
+        public readonly bool noTransfers;
+    }
+}

--- a/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/InterpretedBid.cs
@@ -34,16 +34,19 @@ namespace Trickster.Bots
 
         public string AlternatePoints = string.Empty;
 
+        public readonly BridgeBotOptions Options;
+
         public int Priority = 100;
 
         public InterpretedBid()
         {
         }
 
-        public InterpretedBid(int bid, List<InterpretedBid> history, int index)
+        public InterpretedBid(int bid, List<InterpretedBid> history, int index, BridgeBotOptions options)
         {
             Index = index;
             History = history;
+            Options = options;
 
             this.bid = bid;
             bidIsDeclare = DeclareBid.Is(bid);
@@ -154,11 +157,11 @@ namespace Trickster.Bots
             get { return rxSpaceBefore.Replace(BidMessage.ToString(), m => m.Groups[1].Value + " " + m.Groups[2].Value.ToLowerInvariant()); }
         }
 
-        public static List<InterpretedBid> InterpretHistory(BridgeBidHistory bidHistory)
+        public static List<InterpretedBid> InterpretHistory(BridgeBidHistory bidHistory, BridgeBotOptions options)
         {
             var history = new List<InterpretedBid>();
 
-            for (var i = 0; i < bidHistory.Count; i++) history.Add(new InterpretedBid(bidHistory[i], history, i));
+            for (var i = 0; i < bidHistory.Count; i++) history.Add(new InterpretedBid(bidHistory[i], history, i, options));
 
             return history;
         }
@@ -279,13 +282,13 @@ namespace Trickster.Bots
             if (Jacoby2NT.Interpret(this))
                 return true;
 
-            if (JacobyTransfer.Interpret(this))
+            if (!Options.noTransfers && JacobyTransfer.Interpret(this))
                 return true;
 
             if (NegativeDouble.Interpret(this))
                 return true;
 
-            if (Relay.Interpret(this))
+            if (!Options.noTransfers && Relay.Interpret(this))
                 return true;
 
             if (Stayman.Interpret(this))

--- a/TricksterBots/TricksterBots.csproj
+++ b/TricksterBots/TricksterBots.csproj
@@ -80,8 +80,8 @@
     <ProjectReference Include="..\..\Trickster\TricksterBotClasses\TricksterBotClasses.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'!='Debug'">
-    <Reference Include="TricksterBotClasses, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\TricksterBotClasses.1.7.0\lib\net48\TricksterBotClasses.dll</HintPath>
+    <Reference Include="TricksterBotClasses, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\TricksterBotClasses.1.9.0\lib\net48\TricksterBotClasses.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -105,6 +105,7 @@
     <Compile Include="Bots\Bridge\bridgebid\conventions\StrongOpening.cs" />
     <Compile Include="Bots\Bridge\bridgebid\conventions\TakeoutDouble.cs" />
     <Compile Include="Bots\Bridge\bridgebid\DeclareBid.cs" />
+    <Compile Include="Bots\Bridge\bridgebid\BridgeBotOptions.cs" />
     <Compile Include="Bots\Bridge\bridgebid\InterpretedBid.cs" />
     <Compile Include="Bots\Bridge\bridgebid\phases\Advance.cs" />
     <Compile Include="Bots\Bridge\bridgebid\phases\OpenerRebid.cs" />

--- a/TricksterBots/packages.config
+++ b/TricksterBots/packages.config
@@ -11,5 +11,5 @@
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="TricksterBotClasses" version="1.7.0" targetFramework="net48" />
+  <package id="TricksterBotClasses" version="1.9.0" targetFramework="net48" />
 </packages>

--- a/WebAPI/WebAPI.csproj
+++ b/WebAPI/WebAPI.csproj
@@ -149,8 +149,8 @@
     <ProjectReference Include="..\..\Trickster\TricksterBotClasses\TricksterBotClasses.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'!='Debug'">
-    <Reference Include="TricksterBotClasses, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\TricksterBotClasses.1.7.0\lib\net48\TricksterBotClasses.dll</HintPath>
+    <Reference Include="TricksterBotClasses, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\TricksterBotClasses.1.9.0\lib\net48\TricksterBotClasses.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/WebAPI/packages.config
+++ b/WebAPI/packages.config
@@ -18,5 +18,5 @@
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="TricksterBotClasses" version="1.7.0" targetFramework="net48" />
+  <package id="TricksterBotClasses" version="1.9.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Fix #145 

Allows customizing SAYC bot behavior for players that prefer "natural" bids. Specifically disables Jacoby Transfer and Relay conventions in response to no-trump openings. E.g. responding to a 1NT opening with 2D, 2H, or 2S becomes natural.