### PR TITLE
Bridge: Fix responder rebid after Stayman

### DIFF
--- a/TestBots/Bridge/SAYC/1NT Stayman.pbn
+++ b/TestBots/Bridge/SAYC/1NT Stayman.pbn
@@ -25,3 +25,10 @@ Pass Pass
 1NT Pass 2C Pass
 2S Pass 4S Pass
 Pass Pass
+
+[Event "1NT - Stayman - No Major - No Fit, Invite Game in NT - Decline"]
+[Deal "S:AK7.T92.KT.AJ763 - Q.K753.73.KT9852 -"]
+[Auction "S"]
+1NT Pass 2C Pass
+2D Pass 2NT Pass
+Pass Pass

--- a/TricksterBots/Bots/Bridge/bridgebid/conventions/Stayman.cs
+++ b/TricksterBots/Bots/Bridge/bridgebid/conventions/Stayman.cs
@@ -189,6 +189,16 @@ namespace Trickster.Bots
                 return true;
             }
 
+            //  invite game in 2NT when nothing else fits (does not need to be balanced in this case)
+            if (rebid.declareBid.level == 2 && rebid.declareBid.suit == Suit.Unknown)
+            {
+                rebid.BidPointType = BidPointType.Hcp;
+                rebid.Points.Min = 8;
+                rebid.Points.Max = 9;
+                rebid.Description = "Inviting game";
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
Was passing if partner didn't have a major and there wasn't another suitable suit to explore. Now falls back to 2NT (which doesn't require being balanced in this case).