### PR TITLE
Update LowestCardSlough for BW in NT

### DIFF
--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trickster.Bots;
 using Trickster.cloud;

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trickster.Bots;
 using Trickster.cloud;
@@ -118,6 +118,23 @@ namespace TestBots
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Clubs);
             var suggestion = bot.SuggestNextCard(cardState);
             Assert.AreEqual("3D", suggestion.ToString(), $"Suggested {suggestion.StdNotation} is suit sloughed by partner");
+        }
+
+        [TestMethod]
+        public void SloughLoserInPartnerGoodSuitFirst_NT()
+        {
+            var players = new[]
+            {
+                new TestPlayer(1561, "5D3H9S8S"),
+                new TestPlayer(1400),
+                new TestPlayer(1401) { GoodSuit = Suit.Diamonds },
+                new TestPlayer(1400)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, "2C", trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("5D", suggestion.ToString(), "Prefer shedding a non-winner in partner's GoodSuit over a lower card in another suit");
         }
 
         [TestMethod]

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -497,12 +497,12 @@ namespace Trickster.Bots
                 return legalCards.OrderBy(RankSort).First();
 
             //  else, dump the lowest card from the weakest suit
-            return LowestCardFromWeakestSuit(legalCards, cardsPlayed);
+            return LowestCardFromWeakestSuit(player, legalCards, cardsPlayed, players, isDefending);
         }
 
 
-        //  NOTE: If you're going to edit this in a game-specific way, copy the method to your bot and edit it there
-        private Card LowestCardFromWeakestSuit(IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed)
+        //  NOTE: If you're going to edit this in a game-specific way, override it in your bot
+        protected virtual Card LowestCardFromWeakestSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, PlayersCollectionBase players, bool isDefending)
         {
             var nonTrumpCards = legalCards.Where(c => !IsTrump(c)).ToList();
 

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Trickster.cloud;
@@ -9,6 +9,24 @@ namespace Trickster.Bots
     {
         public WhistBot(WhistOptions options, Suit trumpSuit) : base(options, trumpSuit)
         {
+        }
+
+        protected override Card LowestCardFromWeakestSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, PlayersCollectionBase players, bool isDefending)
+        {
+            //  NT: shed non-winners in partner's introduced suit (GoodSuit) before other suits (issue #303)
+            if (trump == Suit.Unknown && IsPartnership && !isDefending)
+            {
+                var partnerSuit = players.PartnersOf(player).FirstOrDefault(p => p.GoodSuit != Suit.Unknown)?.GoodSuit ?? Suit.Unknown;
+                if (partnerSuit != Suit.Unknown)
+                {
+                    var inPartnerSuit = legalCards.Where(c => EffectiveSuit(c) == partnerSuit).OrderBy(RankSort).ToList();
+                    var loser = inPartnerSuit.FirstOrDefault(c => !IsCardHigh(c, cardsPlayed));
+                    if (loser != null)
+                        return loser;
+                }
+            }
+
+            return base.LowestCardFromWeakestSuit(player, legalCards, cardsPlayed, players, isDefending);
         }
 
         protected override Card TrySignalGoodSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, bool isDefending)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Trickster.cloud;


### PR DESCRIPTION
This PR addresses https://github.com/TricksterCards/TricksterBots/issues/303

It adds a BidWhist specific version of LowestCardFromWeakestSuit in order to prioritize sloughing in the same suit as the partner's primary running suit in NT hands.

