### PR TITLE
BidWhist: Return lead in good partner suit when possible

### DIFF
--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trickster.Bots;
 using Trickster.cloud;
@@ -121,20 +122,38 @@ namespace TestBots
         }
 
         [TestMethod]
-        public void SloughLoserInPartnerGoodSuitFirst_NT()
+        public void LeadBackPartnerGoodSuit_NT()
         {
             var players = new[]
             {
-                new TestPlayer(1561, "5D3H9S8S"),
-                new TestPlayer(1400),
-                new TestPlayer(1401) { GoodSuit = Suit.Diamonds },
-                new TestPlayer(1400)
+                new TestPlayer(1561, "5D3H9S8S", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                new TestPlayer(1401, seat: 2) { GoodSuit = Suit.Diamonds },
+                new TestPlayer(1400, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);
-            var cardState = new TestCardState<WhistOptions>(bot, players, "2C", trumpSuit: Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
             var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("5D", suggestion.ToString(), "Prefer shedding a non-winner in partner's GoodSuit over a lower card in another suit");
+            Assert.AreEqual("5D", suggestion.ToString(), "Come back in partner's suit before a lower card in another suit");
+        }
+
+        [TestMethod]
+        public void LeadBackPartnerBidSuit_NT()
+        {
+            var partnerHeartBid = new WhistBid(Suit.Hearts, 3, true, false);
+            var players = new[]
+            {
+                new TestPlayer(1561, "H8ST", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                new TestPlayer(BidBase.NoBid, "HKT9", seat: 2) { BidHistory = new List<int> { partnerHeartBid } },
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("H8", suggestion.ToString(), "Lead back in partner's auction suit before a boss in another suit");
         }
 
         [TestMethod]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trickster.Bots;
 using Trickster.cloud;

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trickster.Bots;
@@ -139,13 +139,38 @@ namespace TestBots
         }
 
         [TestMethod]
-        public void LeadBackPartnerBidSuit_NT()
+        public void LeadBackSuitPartnerTriedToPromote_NT()
         {
-            var partnerHeartBid = new WhistBid(Suit.Hearts, 3, true, false);
             var players = new[]
             {
-                //  Our hand has a boss elsewhere (AS) but a non-boss in partner's suit (8H).
+                //  Our hand has a boss elsewhere (AS) but a non-boss in the suit partner appears to be promoting (8H).
                 new TestPlayer(1561, "8HAS", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                //  PlayedCard(trickHigh, myPlay): partner's card is 3H (non-boss), promoting hearts
+                new TestPlayer(1401, seat: 2) { PlayedCards = new List<PlayedCard> { new PlayedCard(new Card("KH"), new Card("3H")) } },
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("8H", suggestion.ToString(), "Lead back in suit partner appeared to promote before a boss in another suit");
+        }
+
+        [TestMethod]
+        public void SkipLeadTowardPartnerWhenBossCardsCoverRemainingContract_NT()
+        {
+            var partnerHeartBid = new WhistBid(Suit.Hearts, 3, true, false);
+            //  Declarer bid must match a 7-trick contract so that tricks already won (6) plus one boss covers the bid.
+            var declarerNt7Tricks = (int)new WhistBid(Suit.Unknown, 1, true, false);
+            //  Six tricks already won by declarer + partner; contract is 7. One boss (AS) is enough to cover the last trick,
+            //  so we skip leading back toward partner's auction suit and cash a boss instead.
+            //  24 cards (48 chars) = 6 tricks; must be an even-length card string for Hand parsing
+            var sixTricksWon =
+                "2C3C4C5C6C7C8C9CTCJCQCKCAC2D3D4D5D6D7D8D9DTDJD";
+            var players = new[]
+            {
+                new TestPlayer(declarerNt7Tricks, "8HAS", seat: 0) { CardsTaken = sixTricksWon },
                 new TestPlayer(1400, seat: 1),
                 new TestPlayer(BidBase.NoBid, seat: 2) { BidHistory = new List<int> { partnerHeartBid } },
                 new TestPlayer(1400, seat: 3)
@@ -154,25 +179,7 @@ namespace TestBots
             var bot = GetBot(Suit.Unknown);
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
             var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("8H", suggestion.ToString(), "Lead back in partner's auction suit before a boss in another suit");
-        }
-
-        [TestMethod]
-        public void LeadBackSuitPartnerTriedToPromote_NT()
-        {
-            var players = new[]
-            {
-                //  Our hand has a boss elsewhere (AS) but a non-boss in the suit partner appears to be promoting (8H).
-                new TestPlayer(1561, "8HAS", seat: 0),
-                new TestPlayer(1400, seat: 1),
-                new TestPlayer(1401, seat: 2) { PlayedCards = new List<PlayedCard> { new PlayedCard(new Card("3H"), new Card("4S")) } },
-                new TestPlayer(1400, seat: 3)
-            };
-
-            var bot = GetBot(Suit.Unknown);
-            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
-            var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("8H", suggestion.ToString(), "Lead back in suit partner appeared to promote before a boss in another suit");
+            Assert.AreEqual("AS", suggestion.ToString(), "Cash boss when tricks already won plus bosses meet the contract");
         }
 
         [TestMethod]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trickster.Bots;
 using Trickster.cloud;
@@ -118,6 +118,23 @@ namespace TestBots
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Clubs);
             var suggestion = bot.SuggestNextCard(cardState);
             Assert.AreEqual("3D", suggestion.ToString(), $"Suggested {suggestion.StdNotation} is suit sloughed by partner");
+        }
+
+        [TestMethod]
+        public void SloughLoserInPartnerGoodSuitFirst_NT()
+        {
+            var players = new[]
+            {
+                new TestPlayer(1561, "5D3H9S8S"),
+                new TestPlayer(1400),
+                new TestPlayer(1401) { GoodSuit = Suit.Diamonds },
+                new TestPlayer(1400)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, "2C", trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("5D", suggestion.ToString(), "Prefer shedding a non-winner in partner's GoodSuit over a lower card in another suit");
         }
 
         [TestMethod]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -146,13 +146,16 @@ namespace TestBots
                 //  Our hand has a boss elsewhere (AS) but a non-boss in the suit partner appears to be promoting (8H).
                 new TestPlayer(1561, "8HAS", seat: 0),
                 new TestPlayer(1400, seat: 1),
-                //  PlayedCard(trickHigh, myPlay): partner's card is 3H (non-boss), promoting hearts
-                new TestPlayer(1401, seat: 2) { PlayedCards = new List<PlayedCard> { new PlayedCard(new Card("KH"), new Card("3H")) } },
+                //  Partner (seat 2) led 3H; KH later in the trick is higher in the lead suit (promoting hearts).
+                new TestPlayer(1401, seat: 2),
                 new TestPlayer(1400, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);
-            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown)
+            {
+                cardsPlayedInOrder = "23H32H0AS1KH"
+            };
             var suggestion = bot.SuggestNextCard(cardState);
             Assert.AreEqual("8H", suggestion.ToString(), "Lead back in suit partner appeared to promote before a boss in another suit");
         }

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trickster.Bots;
@@ -155,6 +155,24 @@ namespace TestBots
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
             var suggestion = bot.SuggestNextCard(cardState);
             Assert.AreEqual("8H", suggestion.ToString(), "Lead back in partner's auction suit before a boss in another suit");
+        }
+
+        [TestMethod]
+        public void LeadBackSuitPartnerTriedToPromote_NT()
+        {
+            var players = new[]
+            {
+                //  Our hand has a boss elsewhere (AS) but a non-boss in the suit partner appears to be promoting (8H).
+                new TestPlayer(1561, "8HAS", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                new TestPlayer(1401, seat: 2) { PlayedCards = new List<PlayedCard> { new PlayedCard(new Card("3H"), new Card("4S")) } },
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("8H", suggestion.ToString(), "Lead back in suit partner appeared to promote before a boss in another suit");
         }
 
         [TestMethod]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -144,16 +144,17 @@ namespace TestBots
             var partnerHeartBid = new WhistBid(Suit.Hearts, 3, true, false);
             var players = new[]
             {
-                new TestPlayer(1561, "H8ST", seat: 0),
+                //  Our hand has a boss elsewhere (AS) but a non-boss in partner's suit (8H).
+                new TestPlayer(1561, "8HAS", seat: 0),
                 new TestPlayer(1400, seat: 1),
-                new TestPlayer(BidBase.NoBid, "HKT9", seat: 2) { BidHistory = new List<int> { partnerHeartBid } },
+                new TestPlayer(BidBase.NoBid, seat: 2) { BidHistory = new List<int> { partnerHeartBid } },
                 new TestPlayer(1400, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
             var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("H8", suggestion.ToString(), "Lead back in partner's auction suit before a boss in another suit");
+            Assert.AreEqual("8H", suggestion.ToString(), "Lead back in partner's auction suit before a boss in another suit");
         }
 
         [TestMethod]

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -497,12 +497,12 @@ namespace Trickster.Bots
                 return legalCards.OrderBy(RankSort).First();
 
             //  else, dump the lowest card from the weakest suit
-            return LowestCardFromWeakestSuit(legalCards, cardsPlayed);
+            return LowestCardFromWeakestSuit(player, legalCards, cardsPlayed, players, isDefending);
         }
 
 
-        //  NOTE: If you're going to edit this in a game-specific way, copy the method to your bot and edit it there
-        private Card LowestCardFromWeakestSuit(IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed)
+        //  NOTE: If you're going to edit this in a game-specific way, override it in your bot
+        protected virtual Card LowestCardFromWeakestSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, PlayersCollectionBase players, bool isDefending)
         {
             var nonTrumpCards = legalCards.Where(c => !IsTrump(c)).ToList();
 

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -507,12 +507,12 @@ namespace Trickster.Bots
                 return legalCards.OrderBy(RankSort).First();
 
             //  else, dump the lowest card from the weakest suit
-            return LowestCardFromWeakestSuit(player, legalCards, cardsPlayed, players, isDefending);
+            return LowestCardFromWeakestSuit(legalCards, cardsPlayed);
         }
 
 
-        //  NOTE: If you're going to edit this in a game-specific way, override it in your bot
-        protected virtual Card LowestCardFromWeakestSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, PlayersCollectionBase players, bool isDefending)
+        //  NOTE: If you're going to edit this in a game-specific way, copy the method to your bot and edit it there
+        private Card LowestCardFromWeakestSuit(IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed)
         {
             var nonTrumpCards = legalCards.Where(c => !IsTrump(c)).ToList();
 

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -402,13 +402,16 @@ namespace Trickster.Bots
                     .OrderByDescending(c => cards.Count(c1 => EffectiveSuit(c1) == EffectiveSuit(c))).ToList();
 
                 suggestion = TryLeadTowardPartnerIntroducedSuit(player, legalCards, cardsPlayed, players, isDefending, bossCards);
-
-                if (suggestion == null && bossCards.Count > 0)
+                if (suggestion != null)
+                {
+                    return suggestion;
+                }
+                else if (bossCards.Count > 0)
                 {
                     //  consider leading our "boss" cards favoring boss in our longest suit
                     suggestion = bossCards.First();
                 }
-                else if (suggestion == null && legalCards.Any(c => EffectiveSuit(c) == goodSuitForPartner))
+                else if (legalCards.Any(c => EffectiveSuit(c) == goodSuitForPartner))
                 {
                     //  partner has signaled a "good suit", lead low in it
                     suggestion = legalCards.OrderBy(RankSort).First(c => EffectiveSuit(c) == goodSuitForPartner);

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -315,6 +315,13 @@ namespace Trickster.Bots
             return options.RankSort(c, trumpSuit);
         }
 
+        //  Override in game-specific bots that need it
+        protected virtual Card TryLeadTowardPartnerIntroducedSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
+            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards)
+        {
+            return null;
+        }
+
         //  NOTE: If you're going to edit this in a game-specific way, copy the method to your bot and edit it there
         protected Card TryTakeEm(PlayerBase player, IReadOnlyList<Card> trick, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
             PlayersCollectionBase players, bool isPartnerTakingTrick,
@@ -393,12 +400,15 @@ namespace Trickster.Bots
                 var cards = legalCards;
                 var bossCards = legalCards.Where(c => IsCardHigh(c, cardsPlayed))
                     .OrderByDescending(c => cards.Count(c1 => EffectiveSuit(c1) == EffectiveSuit(c))).ToList();
-                if (bossCards.Count > 0)
+
+                suggestion = TryLeadTowardPartnerIntroducedSuit(player, legalCards, cardsPlayed, players, isDefending, bossCards);
+
+                if (suggestion == null && bossCards.Count > 0)
                 {
                     //  consider leading our "boss" cards favoring boss in our longest suit
                     suggestion = bossCards.First();
                 }
-                else if (legalCards.Any(c => EffectiveSuit(c) == goodSuitForPartner))
+                else if (suggestion == null && legalCards.Any(c => EffectiveSuit(c) == goodSuitForPartner))
                 {
                     //  partner has signaled a "good suit", lead low in it
                     suggestion = legalCards.OrderBy(RankSort).First(c => EffectiveSuit(c) == goodSuitForPartner);

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -317,7 +317,7 @@ namespace Trickster.Bots
 
         //  Override in game-specific bots that need it
         protected virtual Card TryLeadTowardPartnerIntroducedSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
-            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards)
+            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards, string cardsPlayedInOrder = null)
         {
             return null;
         }
@@ -325,7 +325,7 @@ namespace Trickster.Bots
         //  NOTE: If you're going to edit this in a game-specific way, copy the method to your bot and edit it there
         protected Card TryTakeEm(PlayerBase player, IReadOnlyList<Card> trick, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
             PlayersCollectionBase players, bool isPartnerTakingTrick,
-            Card cardTakingTrick, bool isDefending)
+            Card cardTakingTrick, bool isDefending, string cardsPlayedInOrder = null)
         {
             Card suggestion = null;
 
@@ -401,7 +401,7 @@ namespace Trickster.Bots
                 var bossCards = legalCards.Where(c => IsCardHigh(c, cardsPlayed))
                     .OrderByDescending(c => cards.Count(c1 => EffectiveSuit(c1) == EffectiveSuit(c))).ToList();
 
-                suggestion = TryLeadTowardPartnerIntroducedSuit(player, legalCards, cardsPlayed, players, isDefending, bossCards);
+                suggestion = TryLeadTowardPartnerIntroducedSuit(player, legalCards, cardsPlayed, players, isDefending, bossCards, cardsPlayedInOrder);
                 if (suggestion != null)
                 {
                     return suggestion;

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Trickster.cloud;
@@ -9,6 +9,24 @@ namespace Trickster.Bots
     {
         public WhistBot(WhistOptions options, Suit trumpSuit) : base(options, trumpSuit)
         {
+        }
+
+        protected override Card LowestCardFromWeakestSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, PlayersCollectionBase players, bool isDefending)
+        {
+            //  NT: shed non-winners in partner's introduced suit (GoodSuit) before other suits (issue #303)
+            if (trump == Suit.Unknown && IsPartnership && !isDefending)
+            {
+                var partnerSuit = players.PartnersOf(player).FirstOrDefault(p => p.GoodSuit != Suit.Unknown)?.GoodSuit ?? Suit.Unknown;
+                if (partnerSuit != Suit.Unknown)
+                {
+                    var inPartnerSuit = legalCards.Where(c => EffectiveSuit(c) == partnerSuit).OrderBy(RankSort).ToList();
+                    var loser = inPartnerSuit.FirstOrDefault(c => !IsCardHigh(c, cardsPlayed));
+                    if (loser != null)
+                        return loser;
+                }
+            }
+
+            return base.LowestCardFromWeakestSuit(player, legalCards, cardsPlayed, players, isDefending);
         }
 
         protected override Card TrySignalGoodSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, bool isDefending)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -16,9 +16,26 @@ namespace Trickster.Bots
         {
             //  come back in partner's suit (void signal and/or auction) before cashing a boss elsewhere
             if (isDefending)
+            {
                 return null;
+            }
 
-            var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players);
+            //  If we already have enough "boss" cards left to make our team's bid,
+            //  just let them play out rather than trying to come back in partner's suit.
+            var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
+            if (declarer != null)
+            {
+                var contract = new WhistBid(declarer.Bid);
+                var partner = players.PartnerOf(declarer);
+                var tricksTaken = declarer.CardsTaken.Length / 8;
+                if (partner != null)
+                    tricksTaken += partner.CardsTaken.Length / 8;
+
+                if (tricksTaken + bossCards.Count >= contract.Tricks)
+                    return null;
+            }
+
+            var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed);
             if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
                 return null;
 
@@ -31,7 +48,7 @@ namespace Trickster.Bots
             return null;
         }
 
-        private Suit PartnerIntroducedSuitFromAuctionAndSignal(PlayerBase player, PlayersCollectionBase players)
+        private Suit PartnerIntroducedSuitFromAuctionAndSignal(PlayerBase player, PlayersCollectionBase players, IReadOnlyList<Card> cardsPlayed)
         {
             var partner = players.PartnersOf(player).FirstOrDefault();
             if (partner == null)
@@ -40,6 +57,29 @@ namespace Trickster.Bots
             var suit = partner.GoodSuit;
             if (suit != Suit.Unknown && suit != trump)
                 return suit;
+
+
+            if (trump == Suit.Unknown)
+            {
+                //  Try to infer a suit partner is trying to promote by looking at suits where
+                //  they have played a non-boss card in the play history.
+                var playedCards = partner.PlayedCards;
+                if (playedCards != null && playedCards.Any())
+                {
+                    var knownCards = cardsPlayed.Concat(new Hand(player.Hand));
+
+                    var candidateSuit = playedCards
+                        .Where(pc => pc.CardPlayed != null)
+                        .Where(pc => !IsCardHigh(pc.CardPlayed, knownCards))
+                        .Select(pc => EffectiveSuit(pc.CardPlayed))
+                        .FirstOrDefault(s => s != Suit.Unknown && s != Suit.Joker);
+
+                    if (candidateSuit != Suit.Unknown)
+                        return candidateSuit;
+                }
+
+                return Suit.Unknown;
+            }
 
             foreach (var bidInt in partner.BidHistory)
             {

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -12,7 +12,7 @@ namespace Trickster.Bots
         }
 
         protected override Card TryLeadTowardPartnerIntroducedSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
-            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards)
+            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards, string cardsPlayedInOrder = null)
         {
             //  come back in partner's suit (void signal and/or auction) before cashing a boss elsewhere
             if (isDefending)
@@ -35,7 +35,7 @@ namespace Trickster.Bots
                     return null;
             }
 
-            var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed);
+            var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed, cardsPlayedInOrder);
             if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
                 return null;
 
@@ -48,7 +48,8 @@ namespace Trickster.Bots
             return null;
         }
 
-        private Suit PartnerIntroducedSuitFromAuctionAndSignal(PlayerBase player, PlayersCollectionBase players, IReadOnlyList<Card> cardsPlayed)
+        private Suit PartnerIntroducedSuitFromAuctionAndSignal(PlayerBase player, PlayersCollectionBase players, IReadOnlyList<Card> cardsPlayed,
+            string cardsPlayedInOrder)
         {
             var partner = players.PartnersOf(player).FirstOrDefault();
             if (partner == null)
@@ -61,34 +62,35 @@ namespace Trickster.Bots
 
             if (trump == Suit.Unknown)
             {
-                //  Try to infer a suit partner is trying to promote by looking at suits where
-                //  they have played a non-boss card in the play history.
-                var playedCards = partner.PlayedCards;
-                if (playedCards != null && playedCards.Any())
+                //  Infer a suit partner is promoting: walk completed tricks (newest first) and find
+                //  one where partner led and their lead was not the highest card of the lead suit in that trick.
+                var playedOrder = cardsPlayedInOrder;
+                if (!string.IsNullOrEmpty(playedOrder))
                 {
-                    var knownCards = cardsPlayed.Concat(new Hand(player.Hand));
+                    var ordered = GetCardsPlayedInOrder(playedOrder);
+                    if (ordered.Count > 0 && ordered.All(sc => sc.seat >= 0 && sc.seat < players.Count))
+                    {
+                        var tricks = GetCardsPlayedByTrick(playedOrder, players.Count);
+                        for (var t = tricks.Count - 1; t >= 0; t--)
+                        {
+                            var trick = tricks[t];
+                            if (trick.Count == 0 || trick[0].seat != partner.Seat)
+                                continue;
 
-                    var candidateSuit = playedCards
-                        .Where(pc => pc.CardPlayed != null)
-                        .Where(pc => !IsCardHigh(pc.CardPlayed, knownCards))
-                        .Select(pc => EffectiveSuit(pc.CardPlayed))
-                        .FirstOrDefault(s => s != Suit.Unknown && s != Suit.Joker);
+                            var leadCard = trick[0].card;
+                            var leadSuit = EffectiveSuit(leadCard);
+                            if (leadSuit == Suit.Unknown || leadSuit == Suit.Joker)
+                                continue;
 
-                    if (candidateSuit != Suit.Unknown)
-                        return candidateSuit;
+                            var maxRankInLeadSuit = trick
+                                .Where(sc => EffectiveSuit(sc.card) == leadSuit)
+                                .Max(sc => RankSort(sc.card));
+
+                            if (RankSort(leadCard) < maxRankInLeadSuit)
+                                return leadSuit;
+                        }
+                    }
                 }
-
-                return Suit.Unknown;
-            }
-
-            foreach (var bidInt in partner.BidHistory)
-            {
-                var wb = new WhistBid(bidInt);
-                if (!wb.IsDeclareBid)
-                    continue;
-                var s = wb.Suit;
-                if (s != Suit.Unknown && s != Suit.Joker && SuitRank.stdSuits.Contains(s))
-                    return s;
             }
 
             return Suit.Unknown;
@@ -217,7 +219,8 @@ namespace Trickster.Bots
                 new PlayersCollectionBase(this, state.players),
                 state.isPartnerTakingTrick,
                 state.cardTakingTrick,
-                !bid.IsDeclareBid && !bid.IsDeclarePartnerBid);
+                !bid.IsDeclareBid && !bid.IsDeclarePartnerBid,
+                state.cardsPlayedInOrder);
         }
 
         public override List<Card> SuggestPass(SuggestPassState<WhistOptions> state)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -11,22 +11,47 @@ namespace Trickster.Bots
         {
         }
 
-        protected override Card LowestCardFromWeakestSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, PlayersCollectionBase players, bool isDefending)
+        protected override Card TryLeadTowardPartnerIntroducedSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
+            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards)
         {
-            //  NT: shed non-winners in partner's introduced suit (GoodSuit) before other suits (issue #303)
-            if (trump == Suit.Unknown && IsPartnership && !isDefending)
+            //  Bid Whist only: come back in partner's suit (void signal and/or auction) before cashing a boss elsewhere (issue #303)
+            if (options.variation != WhistVariation.BidWhist || isDefending)
+                return null;
+
+            var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players);
+            if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
+                return null;
+
+            var loserInPartnerSuit = legalCards.Where(c => EffectiveSuit(c) == partnerSuit && !IsCardHigh(c, cardsPlayed)).OrderBy(RankSort).FirstOrDefault();
+            if (loserInPartnerSuit != null)
+                return loserInPartnerSuit;
+            if (bossCards.Any(c => EffectiveSuit(c) == partnerSuit))
+                return bossCards.First(c => EffectiveSuit(c) == partnerSuit);
+
+            return null;
+        }
+
+        private Suit PartnerIntroducedSuitFromAuctionAndSignal(PlayerBase player, PlayersCollectionBase players)
+        {
+            var partner = players.PartnersOf(player).FirstOrDefault();
+            if (partner == null)
+                return Suit.Unknown;
+
+            var suit = partner.GoodSuit;
+            if (suit != Suit.Unknown && suit != trump)
+                return suit;
+
+            foreach (var bidInt in partner.BidHistory)
             {
-                var partnerSuit = players.PartnersOf(player).FirstOrDefault(p => p.GoodSuit != Suit.Unknown)?.GoodSuit ?? Suit.Unknown;
-                if (partnerSuit != Suit.Unknown)
-                {
-                    var inPartnerSuit = legalCards.Where(c => EffectiveSuit(c) == partnerSuit).OrderBy(RankSort).ToList();
-                    var loser = inPartnerSuit.FirstOrDefault(c => !IsCardHigh(c, cardsPlayed));
-                    if (loser != null)
-                        return loser;
-                }
+                var wb = new WhistBid(bidInt);
+                if (!wb.IsDeclareBid)
+                    continue;
+                var s = wb.Suit;
+                if (s != Suit.Unknown && s != Suit.Joker && SuitRank.stdSuits.Contains(s))
+                    return s;
             }
 
-            return base.LowestCardFromWeakestSuit(player, legalCards, cardsPlayed, players, isDefending);
+            return Suit.Unknown;
         }
 
         protected override Card TrySignalGoodSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, bool isDefending)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -14,8 +14,8 @@ namespace Trickster.Bots
         protected override Card TryLeadTowardPartnerIntroducedSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
             PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards)
         {
-            //  Bid Whist only: come back in partner's suit (void signal and/or auction) before cashing a boss elsewhere (issue #303)
-            if (options.variation != WhistVariation.BidWhist || isDefending)
+            //  come back in partner's suit (void signal and/or auction) before cashing a boss elsewhere
+            if (isDefending)
                 return null;
 
             var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players);

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Trickster.cloud;


### PR DESCRIPTION
Attempts to address issue #303 by having the bot prefer to come back in the good suit for their partner when leading before attempting to cash boss cards elsewhere.

It adds a TryLeadTowardPartnerIntroducedSuit function in base bot that is overridden in Bid Whist to prefer following partner's good suit, followed by bid suit.

Adds 2 tests to the whistbot to check the above cases