### PR TITLE
Bid Whist: Don't lead suit partner is void in NT

### DIFF
--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -109,6 +109,34 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void NT_OpeningLead_TryTakeEmCannotLeadNonBossFromPartnerVoidSuit()
+        {
+            // Regression for PR #377: legalCards is narrowed before TryTakeEm so non-boss hearts are removed
+            // when partner is known void. TryTakeEm only draws from that list (including LowestCardFromWeakestSuit),
+            // so it must never return 5H even though 5H is in the physical hand.
+            var partner = new TestPlayer(1400, "");
+            partner.VoidSuits.Add(Suit.Hearts);
+            var players = new[]
+            {
+                new TestPlayer(1400, "AH5H9D2D", cardsTaken: ""),
+                new TestPlayer(1561, "", cardsTaken: "2H3H4H6H7H8H"),
+                partner,
+                new TestPlayer(1401, "", cardsTaken: "9HTHJHQHKH")
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+
+            Assert.AreNotEqual(
+                "5H",
+                suggestion.ToString(),
+                "Non-boss heart must be filtered out before TryTakeEm; otherwise dumping logic could lead it from a partner-void suit");
+            if (suggestion.suit == Suit.Hearts)
+                Assert.AreEqual(Rank.Ace, suggestion.rank, "Only the boss heart should remain playable in hearts for this layout");
+        }
+
+        [TestMethod]
         public void SloughJokerFirstWhenVoidInNT()
         {
             var players = new[]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -69,6 +69,26 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void DontLeadPartnerVoidSuitInNT_WhenAlternativeExists()
+        {
+            // Partner is known void in hearts (e.g. from earlier play); leader can lead hearts or diamonds — prefer diamonds (issue #146).
+            var partner = new TestPlayer(1400, "");
+            partner.VoidSuits.Add(Suit.Hearts);
+            var players = new[]
+            {
+                new TestPlayer(1400, "2H3D"),
+                new TestPlayer(1561),
+                partner,
+                new TestPlayer(1401)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual(Suit.Diamonds, suggestion.suit, "Should not lead a suit partner is known to be void in");
+        }
+
+        [TestMethod]
         public void SloughJokerFirstWhenVoidInNT()
         {
             var players = new[]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -89,6 +89,26 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void MayLeadBossInPartnerVoidSuitInNT_WhenItWinsTheTrick()
+        {
+            // Partner is void in hearts; we still allow leading the top remaining heart (boss) to cash a trick.
+            var partner = new TestPlayer(1400, "");
+            partner.VoidSuits.Add(Suit.Hearts);
+            var players = new[]
+            {
+                new TestPlayer(1400, "AH3D", cardsTaken: ""),
+                new TestPlayer(1561, "", cardsTaken: "2H3H4H5H6H7H8H9HTHJHQHKH"),
+                partner,
+                new TestPlayer(1401)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("AH", suggestion.ToString(), "Boss heart should remain a legal lead even if partner is void in hearts");
+        }
+
+        [TestMethod]
         public void SloughJokerFirstWhenVoidInNT()
         {
             var players = new[]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -91,7 +91,7 @@ namespace TestBots
         [TestMethod]
         public void MayLeadBossInPartnerVoidSuitInNT_WhenItWinsTheTrick()
         {
-            // Partner is void in hearts; we still allow leading the top remaining heart (boss) to cash a trick.
+            // Partner is void in hearts; we still allow leading the top remaining heart to cash a trick.
             var partner = new TestPlayer(1400, "");
             partner.VoidSuits.Add(Suit.Hearts);
             var players = new[]

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -217,7 +217,10 @@ namespace Trickster.Bots
                     players.PartnerIsVoidInSuit(state.player, new Card(s, Rank.Ace), state.cardsPlayed)).ToList();
                 if (avoidPartnerVoidSuits.Count > 0)
                 {
-                    legalCards = legalCards.Where(c => !avoidPartnerVoidSuits.Contains(EffectiveSuit(c))).ToList();
+                    var withoutPartnerVoidLead = legalCards.Where(c =>
+                        !avoidPartnerVoidSuits.Contains(EffectiveSuit(c)) || IsCardHigh(c, state.cardsPlayed)).ToList();
+                    if (withoutPartnerVoidLead.Count > 0)
+                        legalCards = withoutPartnerVoidLead;
                 }
             }
 

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -206,10 +206,19 @@ namespace Trickster.Bots
             var bid = new WhistBid(state.player.Bid);
             var legalCards = state.legalCards;
 
-            // Avoid leading Jokers in NT
-            if (state.trick.Count == 0 && state.trumpSuit == Suit.Unknown && legalCards.Any(c => c.suit == Suit.Joker) && legalCards.Any(c => c.suit != Suit.Joker))
-            {
-                legalCards = legalCards.Where(c => c.suit != Suit.Joker).ToList();
+            // Avoid leading Jokers or suits partner is known to be void in in NT
+            if (state.trick.Count == 0 && state.trumpSuit == Suit.Unknown) {
+                if (legalCards.Any(c => c.suit == Suit.Joker) && legalCards.Any(c => c.suit != Suit.Joker))
+                {
+                    legalCards = legalCards.Where(c => c.suit != Suit.Joker).ToList();
+                }
+                var players = new PlayersCollectionBase(this, state.players);
+                var avoidPartnerVoidSuits = SuitRank.stdSuits.Where(s =>
+                    players.PartnerIsVoidInSuit(state.player, new Card(s, Rank.Ace), state.cardsPlayed)).ToList();
+                if (avoidPartnerVoidSuits.Count > 0)
+                {
+                    legalCards = legalCards.Where(c => !avoidPartnerVoidSuits.Contains(EffectiveSuit(c))).ToList();
+                }
             }
 
             return TryTakeEm(state.player,

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -206,7 +206,7 @@ namespace Trickster.Bots
             var bid = new WhistBid(state.player.Bid);
             var legalCards = state.legalCards;
 
-            // Avoid leading Jokers or suits partner is known to be void in in NT
+            // Avoid leading Jokers or suits partner is known to be void in NT
             if (state.trick.Count == 0 && state.trumpSuit == Suit.Unknown) {
                 if (legalCards.Any(c => c.suit == Suit.Joker) && legalCards.Any(c => c.suit != Suit.Joker))
                 {


### PR DESCRIPTION
Addresses https://github.com/TricksterCards/TricksterBots/issues/146 by updating our bidwhist Joker leading override to also contain logic to avoid leading suits partner is void in for NT hands.