### PR TITLE
Return highest card in partner's suit

### DIFF
--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -186,7 +186,7 @@ namespace TestBots
             var bot = GetBot(Suit.Clubs);
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Clubs);
             var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("3D", suggestion.ToString(), $"Suggested {suggestion.StdNotation} is suit sloughed by partner");
+            Assert.AreEqual("4D", suggestion.ToString(), $"Suggested {suggestion.StdNotation} is highest card in suit sloughed by partner");
         }
 
         [TestMethod]
@@ -194,7 +194,7 @@ namespace TestBots
         {
             var players = new[]
             {
-                new TestPlayer(1561, "5D3H9S8S", seat: 0),
+                new TestPlayer(1561, "5D9DAS3H", seat: 0),
                 new TestPlayer(1400, seat: 1),
                 new TestPlayer(1401, seat: 2) { GoodSuit = Suit.Diamonds },
                 new TestPlayer(1400, seat: 3)
@@ -203,7 +203,7 @@ namespace TestBots
             var bot = GetBot(Suit.Unknown);
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
             var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("5D", suggestion.ToString(), "Come back in partner's suit before a lower card in another suit");
+            Assert.AreEqual("9D", suggestion.ToString(), "Come back in partner's suit with the highest card before an off-suit boss");
         }
 
         [TestMethod]
@@ -211,8 +211,8 @@ namespace TestBots
         {
             var players = new[]
             {
-                //  Our hand has a boss elsewhere (AS) but a non-boss in the suit partner appears to be promoting (8H).
-                new TestPlayer(1561, "8HAS", seat: 0),
+                //  Our hand has a boss elsewhere (AS) and multiple hearts in the suit partner appears to be promoting.
+                new TestPlayer(1561, "3H8HAS", seat: 0),
                 new TestPlayer(1400, seat: 1),
                 //  Partner (seat 2) led 3H; KH later in the trick is higher in the lead suit (promoting hearts).
                 new TestPlayer(1401, seat: 2),
@@ -225,7 +225,42 @@ namespace TestBots
                 cardsPlayedInOrder = "23H32H0AS1KH"
             };
             var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("8H", suggestion.ToString(), "Lead back in suit partner appeared to promote before a boss in another suit");
+            Assert.AreEqual("8H", suggestion.ToString(), "Lead highest back in suit partner appeared to promote before a boss in another suit");
+        }
+
+        [TestMethod]
+        public void LeadBackPartnerPromotedSuitAgainBeforeOtherBoss_NT()
+        {
+            var firstLeadPlayers = new[]
+            {
+                new TestPlayer(1561, "8HQHAS", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                new TestPlayer(1401, seat: 2),
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var firstLeadState = new TestCardState<WhistOptions>(bot, firstLeadPlayers, trumpSuit: Suit.Unknown)
+            {
+                cardsPlayedInOrder = "23H32H0AS1KH"
+            };
+            var firstSuggestion = bot.SuggestNextCard(firstLeadState);
+            Assert.AreEqual("QH", firstSuggestion.ToString(), "First lead should be the highest card in partner's promoted suit");
+
+            var secondLeadPlayers = new[]
+            {
+                new TestPlayer(1561, "8HAS", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                new TestPlayer(1401, seat: 2),
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var secondLeadState = new TestCardState<WhistOptions>(bot, secondLeadPlayers, trumpSuit: Suit.Unknown)
+            {
+                cardsPlayedInOrder = "23H32H0AS1KH"
+            };
+            var secondSuggestion = bot.SuggestNextCard(secondLeadState);
+            Assert.AreEqual("8H", secondSuggestion.ToString(), "If still on lead, continue with highest remaining card in partner's suit before off-suit boss cards");
         }
 
         [TestMethod]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -9,6 +9,12 @@ namespace TestBots
     [TestClass]
     public class TestWhistBot
     {
+        // Declare bid on the actual declarer (partner across the table from the lead)
+        private static readonly int DeclarerSeatBid = (int)new WhistBid(Suit.Clubs, 3, false, true);
+
+        // Bid for the leading player so Whist treats them as offense (partner bid), not defense
+        private static readonly int DeclarersPartnerSeatBid = (int)WhistBid.DeclarerPartnerBid;
+
         [TestMethod]
         public void DiscardJokersInNT()
         {
@@ -177,10 +183,10 @@ namespace TestBots
         {
             var players = new[]
             {
-                new TestPlayer(1564, "4D3DTH2S", cardsTaken: "2C3C4C5C6C7C8C9CTCJCQCLJHJKCTDAC"),
-                new TestPlayer(1400),
-                new TestPlayer(1401) { GoodSuit = Suit.Diamonds },
-                new TestPlayer(1400)
+                new TestPlayer(DeclarersPartnerSeatBid, "4D3DTH2S", cardsTaken: "2C3C4C5C6C7C8C9CTCJCQCLJHJKCTDAC"),
+                new TestPlayer(BidBase.NoBid),
+                new TestPlayer(DeclarerSeatBid, "") { GoodSuit = Suit.Diamonds },
+                new TestPlayer(BidBase.NoBid)
             };
 
             var bot = GetBot(Suit.Clubs);
@@ -194,10 +200,10 @@ namespace TestBots
         {
             var players = new[]
             {
-                new TestPlayer(1561, "5D9DAS3H", seat: 0),
-                new TestPlayer(1400, seat: 1),
-                new TestPlayer(1401, seat: 2) { GoodSuit = Suit.Diamonds },
-                new TestPlayer(1400, seat: 3)
+                new TestPlayer(DeclarersPartnerSeatBid, "5D9DAS3H", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarerSeatBid, "", seat: 2) { GoodSuit = Suit.Diamonds },
+                new TestPlayer(BidBase.NoBid, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);
@@ -212,11 +218,11 @@ namespace TestBots
             var players = new[]
             {
                 //  Our hand has a boss elsewhere (AS) and multiple hearts in the suit partner appears to be promoting.
-                new TestPlayer(1561, "3H8HAS", seat: 0),
-                new TestPlayer(1400, seat: 1),
+                new TestPlayer(DeclarersPartnerSeatBid, "3H8HAS", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
                 //  Partner (seat 2) led 3H; KH later in the trick is higher in the lead suit (promoting hearts).
-                new TestPlayer(1401, seat: 2),
-                new TestPlayer(1400, seat: 3)
+                new TestPlayer(DeclarerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);
@@ -233,10 +239,10 @@ namespace TestBots
         {
             var firstLeadPlayers = new[]
             {
-                new TestPlayer(1561, "8HQHAS", seat: 0),
-                new TestPlayer(1400, seat: 1),
-                new TestPlayer(1401, seat: 2),
-                new TestPlayer(1400, seat: 3)
+                new TestPlayer(DeclarersPartnerSeatBid, "8HQHAS", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);
@@ -249,10 +255,10 @@ namespace TestBots
 
             var secondLeadPlayers = new[]
             {
-                new TestPlayer(1561, "8HAS", seat: 0),
-                new TestPlayer(1400, seat: 1),
-                new TestPlayer(1401, seat: 2),
-                new TestPlayer(1400, seat: 3)
+                new TestPlayer(DeclarersPartnerSeatBid, "8HAS", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
             };
 
             var secondLeadState = new TestCardState<WhistOptions>(bot, secondLeadPlayers, trumpSuit: Suit.Unknown)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -23,22 +23,26 @@ namespace Trickster.Bots
             //  If we already have enough "boss" cards left to make our team's bid,
             //  just let them play out rather than trying to come back in partner's suit.
             var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
+            var declarersPartner = declarer != null ? players.PartnerOf(declarer) : null;
+            var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
             if (declarer != null)
             {
                 var contract = new WhistBid(declarer.Bid);
-                var partner = players.PartnerOf(declarer);
                 var tricksTaken = declarer.CardsTaken.Length / 8;
-                if (partner != null)
-                    tricksTaken += partner.CardsTaken.Length / 8;
+                if (declarersPartner != null)
+                    tricksTaken += declarersPartner.CardsTaken.Length / 8;
 
                 if (tricksTaken + bossCards.Count >= contract.Tricks)
                     return null;
             }
 
+            if (isCurrentSeatDeclarer)
+                return null;
+
             var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed, cardsPlayedInOrder);
             if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
                 return null;
-            
+
             // If we have cards in the partner's suit, lead the highest card in that suit to indicate
             // to partner what our hand looks like.
             return legalCards

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -38,14 +38,13 @@ namespace Trickster.Bots
             var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed, cardsPlayedInOrder);
             if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
                 return null;
-
-            var loserInPartnerSuit = legalCards.Where(c => EffectiveSuit(c) == partnerSuit && !IsCardHigh(c, cardsPlayed)).OrderBy(RankSort).FirstOrDefault();
-            if (loserInPartnerSuit != null)
-                return loserInPartnerSuit;
-            if (bossCards.Any(c => EffectiveSuit(c) == partnerSuit))
-                return bossCards.First(c => EffectiveSuit(c) == partnerSuit);
-
-            return null;
+            
+            // If we have cards in the partner's suit, lead the highest card in that suit to indicate
+            // to partner what our hand looks like.
+            return legalCards
+                .Where(c => EffectiveSuit(c) == partnerSuit)
+                .OrderByDescending(RankSort)
+                .FirstOrDefault();
         }
 
         private Suit PartnerIntroducedSuitFromAuctionAndSignal(PlayerBase player, PlayersCollectionBase players, IReadOnlyList<Card> cardsPlayed,


### PR DESCRIPTION
Continues work from https://github.com/TricksterCards/TricksterBots/pull/376

When returning good suit back to partner, offensive bot should lead with the highest card in that suit to better communicate their hand.