### PR TITLE
NT: offensive partners should slough bad suit instead of signaling good

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,0 @@
-[*.cs]
-charset = utf-8-bom

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -160,6 +160,28 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void NT_DeclarerSloughWhenVoid_UsesWeakestSuitDump_NotGoodSuitSignal()
+        {
+            // NT declaring side: TrySignalGoodSuit routes to LowestCardFromWeakestSuitNT (not base Lavinthal).
+            // Void in clubs; singleton 2H is not boss while ace of hearts is still unplayed; expect that slough.
+            var declarerNt = (int)new WhistBid(Suit.Unknown, 1, true, true);
+            var players = new[]
+            {
+                new TestPlayer(declarerNt, "2H9S8S7S", seat: 0),
+                new TestPlayer(1400, seat: 1, cardsTaken: "3H4H5H6H7H8H9HTHJHQHKH"),
+                new TestPlayer(1401, seat: 2),
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, "KC", trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+
+            Assert.AreEqual("2H", suggestion.ToString(),
+                $"Expected singleton heart slough from weakest-suit logic, got {suggestion.StdNotation}");
+        }
+
+        [TestMethod]
         public void SignalGoodSuitOnFirstSlough_Lead()
         {
             var players = new[]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -160,7 +160,7 @@ namespace TestBots
         }
 
         [TestMethod]
-        public void NT_DeclarerSloughWhenVoid_UsesWeakestSuitDump_NotGoodSuitSignal()
+        public void NT_OffenseSloughWeakSuit()
         {
             // NT declaring side: TrySignalGoodSuit routes to LowestCardFromWeakestSuitNT (not base Lavinthal).
             // Void in clubs; singleton 2H is not boss while ace of hearts is still unplayed; expect that slough.

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -162,7 +162,7 @@ namespace TestBots
         [TestMethod]
         public void NT_OffenseSloughWeakSuit()
         {
-            // NT declaring side: TrySignalGoodSuit routes to LowestCardFromWeakestSuitNT (not base Lavinthal).
+            // NT declaring side: TrySignalGoodSuit routes to LowestCardFromWeakestSuitNT instead of signaling strong suit.
             // Void in clubs; singleton 2H is not boss while ace of hearts is still unplayed; expect that slough.
             var declarerNt = (int)new WhistBid(Suit.Unknown, 1, true, true);
             var players = new[]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -235,6 +235,27 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void LeadBackPartnerGoodSuit_NT_BidderLeadsLowest()
+        {
+            var declarerNtBid = (int)new WhistBid(Suit.Unknown, 1, true, false);
+            var players = new[]
+            {
+                new TestPlayer(declarerNtBid, "5H8H2C3C", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarersPartnerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown)
+            {
+                cardsPlayedInOrder = "23H32H0AS1KH"
+            };
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("5H", suggestion.ToString(), "NT declarer with no bosses leads lowest back in suit partner signaled from the lead");
+        }
+
+        [TestMethod]
         public void LeadBackSuitPartnerTriedToPromote_NT()
         {
             var players = new[]

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -315,20 +315,6 @@ namespace Trickster.Bots
             return options.RankSort(c, trumpSuit);
         }
 
-        //  Override in game-specific bots that need it
-        protected virtual Card TryLeadTowardPartnerIntroducedSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
-            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards, string cardsPlayedInOrder = null)
-        {
-            return null;
-        }
-
-        //  Override in game-specific bots that need lead-time suit signaling behavior
-        protected virtual Card TrySignalGoodSuitFromLead(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
-            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards, string cardsPlayedInOrder = null)
-        {
-            return null;
-        }
-
         //  NOTE: If you're going to edit this in a game-specific way, copy the method to your bot and edit it there
         protected Card TryTakeEm(PlayerBase player, IReadOnlyList<Card> trick, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
             PlayersCollectionBase players, bool isPartnerTakingTrick,
@@ -408,17 +394,7 @@ namespace Trickster.Bots
                 var bossCards = legalCards.Where(c => IsCardHigh(c, cardsPlayed))
                     .OrderByDescending(c => cards.Count(c1 => EffectiveSuit(c1) == EffectiveSuit(c))).ToList();
 
-                suggestion = TryLeadTowardPartnerIntroducedSuit(player, legalCards, cardsPlayed, players, isDefending, bossCards, cardsPlayedInOrder);
-                if (suggestion != null)
-                {
-                    return suggestion;
-                }
-                suggestion = TrySignalGoodSuitFromLead(player, legalCards, cardsPlayed, players, isDefending, bossCards, cardsPlayedInOrder);
-                if (suggestion != null)
-                {
-                    return suggestion;
-                }
-                else if (bossCards.Count > 0)
+                if (bossCards.Count > 0)
                 {
                     //  consider leading our "boss" cards favoring boss in our longest suit
                     suggestion = bossCards.First();

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -234,7 +234,7 @@ namespace Trickster.Bots
             if (trump == Suit.Unknown && legalCards.Any(c => c.suit == Suit.Joker))
                 return legalCards.First(c => c.suit == Suit.Joker);
 
-            //  NT offense: dump from weakest suit rather than Lavinthal-style strength signals
+            //  NT offense: dump from weakest suit rather than signaling strong suit
             if (trump == Suit.Unknown && !isDefending)
                 return LowestCardFromWeakestSuitNT(legalCards, cardsPlayed);
 

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -191,11 +191,62 @@ namespace Trickster.Bots
             return Suit.Unknown;
         }
 
+        //  NT slough helper with some logic based on base bot's LowestCardFromWeakestSuit: pick a low discard from a weak suit.
+        private Card LowestCardFromWeakestSuitNT(IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed)
+        {
+            var cards = legalCards as IList<Card> ?? legalCards.ToList();
+
+            var suitCounts = cards.GroupBy(EffectiveSuit).Select(g => new { suit = g.Key, count = g.Count() }).ToList();
+
+            //  try to ditch a singleton that's not "boss" and whose suit has the most outstanding cards
+            var bestSingletonSuitCount = suitCounts.Where(sc => sc.count == 1)
+                .Where(sc => !IsCardHigh(cards.Single(c => EffectiveSuit(c) == sc.suit), cardsPlayed))
+                .OrderBy(sc => cardsPlayed.Count(c => EffectiveSuit(c) == sc.suit)).FirstOrDefault();
+
+            if (bestSingletonSuitCount != null)
+                return cards.Single(c => EffectiveSuit(c) == bestSingletonSuitCount.suit);
+
+            //  now we look at doubletons in the order of the number of remaining cards in the suit
+            var doubletonSuitCounts = suitCounts.Where(sc => sc.count == 2).OrderBy(sc => cardsPlayed.Count(c => EffectiveSuit(c) == sc.suit)).ToList();
+
+            foreach (var sc in doubletonSuitCounts)
+            {
+                var suitCards = cards.Where(c => EffectiveSuit(c) == sc.suit).OrderBy(RankSort).ToList();
+
+                //  High is boss and low isn't "touching" it in suit order (honors / adjacent strength)
+                if (IsCardHigh(suitCards[1], cardsPlayed) && !AreCardsEquivalent(suitCards[0], suitCards[1], cardsPlayed))
+                    return suitCards[0];
+
+                //  Don't pitch the low if either card is the unique second-top in the suit (e.g. king under ace) for high or low contracts
+                if (!suitCards.Any(c => HasSoleUnplayedCardStrictlyAbove(c, cardsPlayed)))
+                    return suitCards[0];
+            }
+
+            //  return the lowest card from the longest suit
+            return cards.OrderByDescending(c => cards.Count(c1 => EffectiveSuit(c1) == c.suit)).ThenBy(RankSort).First();
+        }
+
+        private bool HasSoleUnplayedCardStrictlyAbove(Card c, IEnumerable<Card> cardsPlayed)
+        {
+            if (IsCardHigh(c, cardsPlayed))
+                return false;
+
+            var r = RankSort(c);
+            return CardsInSuit(c).Count(card => RankSort(card) > r && !IsCardRecordedAsPlayed(card, cardsPlayed)) == 1;
+        }
+
+        private static bool IsCardRecordedAsPlayed(Card card, IEnumerable<Card> cardsPlayed) =>
+            cardsPlayed.Any(p => p.suit == card.suit && p.rank == card.rank);
+
         protected override Card TrySignalGoodSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, bool isDefending)
         {
             //  In no-trump, slough jokers before signaling a good suit (jokers are dead in NT)
             if (trump == Suit.Unknown && legalCards.Any(c => c.suit == Suit.Joker))
                 return legalCards.First(c => c.suit == Suit.Joker);
+
+            //  NT offense: dump from weakest suit rather than Lavinthal-style strength signals
+            if (trump == Suit.Unknown && !isDefending && IsPartnership)
+                return LowestCardFromWeakestSuitNT(legalCards, cardsPlayed);
 
             return base.TrySignalGoodSuit(player, legalCards, cardsPlayed, isDefending);
         }

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -212,18 +212,18 @@ namespace Trickster.Bots
             foreach (var sc in doubletonSuitCounts)
             {
                 var suitCards = cards.Where(c => EffectiveSuit(c) == sc.suit).OrderBy(RankSort).ToList();
+                var low = suitCards[0];
+                var high = suitCards[1];
 
-
-                if (IsCardHigh(suitCards[1], cardsPlayed) && !AreCardsEquivalent(suitCards[0], suitCards[1], cardsPlayed))
-                    return suitCards[0];
-
-                if (!suitCards.Any(c => HasSoleUnplayedCardStrictlyAbove(c, cardsPlayed)))
-                    return suitCards[0];
+                if (!IsCardHigh(high, cardsPlayed) && !HasSoleUnplayedCardStrictlyAbove(high, cardsPlayed))
+                    return low;
             }
 
-            //  return the lowest card from the longest suit
-            return cards.OrderByDescending(c => cards.Count(c1 => EffectiveSuit(c1) == c.suit)).ThenBy(RankSort).First();
+            //  return the lowest card from the shortest suit
+            return cards.OrderBy(c => cards.Count(c1 => EffectiveSuit(c1) == c.suit)).ThenBy(RankSort).First();
         }
+
+       
 
         private bool HasSoleUnplayedCardStrictlyAbove(Card c, IEnumerable<Card> cardsPlayed)
         {
@@ -244,7 +244,7 @@ namespace Trickster.Bots
                 return legalCards.First(c => c.suit == Suit.Joker);
 
             //  NT offense: dump from weakest suit rather than Lavinthal-style strength signals
-            if (trump == Suit.Unknown && !isDefending && IsPartnership)
+            if (trump == Suit.Unknown && !isDefending)
                 return LowestCardFromWeakestSuitNT(legalCards, cardsPlayed);
 
             return base.TrySignalGoodSuit(player, legalCards, cardsPlayed, isDefending);

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -113,15 +113,20 @@ namespace Trickster.Bots
                 : longestSuitGroup.OrderBy(RankSort).FirstOrDefault();
         }
 
-        private bool TopCanBeCovered(Card top, IReadOnlyList<Card> cardsPlayed)
+        private int UnplayedCardCountAbove(Card c, IReadOnlyList<Card> cardsPlayed)
         {
-            var suit = EffectiveSuit(top);
-            var topRank = RankSort(top);
-            var highestInSuit = HighRankInSuit(top);
-            var rankGapToDeckTop = highestInSuit - topRank;
-            var playedAboveTop = cardsPlayed.Count(c => EffectiveSuit(c) == suit && RankSort(c) > topRank);
-            return rankGapToDeckTop - playedAboveTop <= 1;
+            var suit = EffectiveSuit(c);
+            var rank = RankSort(c);
+            var rankGapToDeckTop = HighRankInSuit(c) - rank;
+            var playedAbove = cardsPlayed.Count(p => EffectiveSuit(p) == suit && RankSort(p) > rank);
+            return rankGapToDeckTop - playedAbove;
         }
+
+        private bool TopCanBeCovered(Card top, IReadOnlyList<Card> cardsPlayed) =>
+            UnplayedCardCountAbove(top, cardsPlayed) <= 1;
+
+        private bool HasOnlyOneCardAbove(Card c, IReadOnlyList<Card> cardsPlayed) =>
+            !IsCardHigh(c, cardsPlayed) && UnplayedCardCountAbove(c, cardsPlayed) == 1;
 
         private static int TricksTaken(PlayerBase player)
         {
@@ -215,27 +220,13 @@ namespace Trickster.Bots
                 var low = suitCards[0];
                 var high = suitCards[1];
 
-                if (!IsCardHigh(high, cardsPlayed) && !HasSoleUnplayedCardStrictlyAbove(high, cardsPlayed))
+                if (!IsCardHigh(high, cardsPlayed) && !HasOnlyOneCardAbove(high, cardsPlayed))
                     return low;
             }
 
             //  return the lowest card from the shortest suit
             return cards.OrderBy(c => cards.Count(c1 => EffectiveSuit(c1) == c.suit)).ThenBy(RankSort).First();
         }
-
-       
-
-        private bool HasSoleUnplayedCardStrictlyAbove(Card c, IEnumerable<Card> cardsPlayed)
-        {
-            if (IsCardHigh(c, cardsPlayed))
-                return false;
-
-            var r = RankSort(c);
-            return CardsInSuit(c).Count(card => RankSort(card) > r && !IsCardRecordedAsPlayed(card, cardsPlayed)) == 1;
-        }
-
-        private static bool IsCardRecordedAsPlayed(Card card, IEnumerable<Card> cardsPlayed) =>
-            cardsPlayed.Any(p => p.suit == card.suit && p.rank == card.rank);
 
         protected override Card TrySignalGoodSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, bool isDefending)
         {

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -213,11 +213,10 @@ namespace Trickster.Bots
             {
                 var suitCards = cards.Where(c => EffectiveSuit(c) == sc.suit).OrderBy(RankSort).ToList();
 
-                //  High is boss and low isn't "touching" it in suit order (honors / adjacent strength)
+
                 if (IsCardHigh(suitCards[1], cardsPlayed) && !AreCardsEquivalent(suitCards[0], suitCards[1], cardsPlayed))
                     return suitCards[0];
 
-                //  Don't pitch the low if either card is the unique second-top in the suit (e.g. king under ace) for high or low contracts
                 if (!suitCards.Any(c => HasSoleUnplayedCardStrictlyAbove(c, cardsPlayed)))
                     return suitCards[0];
             }

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -353,11 +353,13 @@ namespace Trickster.Bots
             {
                 if (state.trumpSuit == Suit.Unknown)
                 {
+                    // Don't lead jokers in no-trump
                     if (legalCards.Any(c => c.suit == Suit.Joker) && legalCards.Any(c => c.suit != Suit.Joker))
                     {
                         legalCards = legalCards.Where(c => c.suit != Suit.Joker).ToList();
                     }
 
+                    // Avoid leading a suit partner is known to be void in
                     var avoidPartnerVoidSuits = SuitRank.stdSuits.Where(s =>
                         players.PartnerIsVoidInSuit(state.player, new Card(s, Rank.Ace), state.cardsPlayed)).ToList();
                     if (avoidPartnerVoidSuits.Count > 0)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -225,14 +225,17 @@ namespace Trickster.Bots
             if (trump != Suit.Unknown)
                 return null;
 
+            // If for some reason we are leading and this was called, return null
             var firstCardInTrick = trick.FirstOrDefault(IsOfValue);
             if (firstCardInTrick == null)
                 return null;
 
+            // Fall back to TryTakeEm if we can follow suit
             var trickSuit = EffectiveSuit(firstCardInTrick);
             if (legalCards.Any(c => EffectiveSuit(c) == trickSuit))
                 return null;
 
+            // If we have a joker, slough it
             if (legalCards.Any(c => c.suit == Suit.Joker))
                 return legalCards.First(c => c.suit == Suit.Joker);
 
@@ -345,6 +348,7 @@ namespace Trickster.Bots
             var legalCards = state.legalCards;
             var players = new PlayersCollectionBase(this, state.players);
 
+            // Leading suggestions
             if (state.trick.Count == 0)
             {
                 if (state.trumpSuit == Suit.Unknown)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -107,18 +107,27 @@ namespace Trickster.Bots
 
             var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
             var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
-
-            if (isCurrentSeatDeclarer)
-                return null;
+            var isPartnerDeclarer = declarer != null && players.PartnerOf(player)?.Seat == declarer.Seat;
 
             var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed, cardsPlayedInOrder);
             if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
                 return null;
 
-            return legalCards
-                .Where(c => EffectiveSuit(c) == partnerSuit)
-                .OrderByDescending(RankSort)
-                .FirstOrDefault();
+            if (isCurrentSeatDeclarer && trump == Suit.Unknown)
+            {
+                //  NT declarer: come back in the suit partner signaled from the lead (lowest card).
+                return legalCards
+                    .Where(c => EffectiveSuit(c) == partnerSuit)
+                    .OrderBy(RankSort)
+                    .FirstOrDefault();
+            } else if (isPartnerDeclarer) {
+                return legalCards
+                    .Where(c => EffectiveSuit(c) == partnerSuit)
+                    .OrderByDescending(RankSort)
+                    .FirstOrDefault();
+            }
+
+            return null;
         }
 
         private Card TrySignalGoodSuitOnLead(PlayerBase player, IReadOnlyList<Card> legalCards,

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -11,108 +11,6 @@ namespace Trickster.Bots
         {
         }
 
-        protected override Card TryLeadTowardPartnerIntroducedSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
-            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards, string cardsPlayedInOrder = null)
-        {
-            //  come back in partner's suit (void signal and/or auction) before cashing a boss elsewhere
-            if (isDefending)
-            {
-                return null;
-            }
-
-            //  If we already have enough "boss" cards left to make our team's bid,
-            //  just let them play out rather than trying to come back in partner's suit.
-            if (CanCashBossCardsToCoverContract(players, bossCards))
-                return null;
-
-            var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
-            var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
-
-            if (isCurrentSeatDeclarer)
-                return null;
-
-            var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed, cardsPlayedInOrder);
-            if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
-                return null;
-
-            // If we have cards in the partner's suit, lead the highest card in that suit to indicate
-            // to partner what our hand looks like.
-            return legalCards
-                .Where(c => EffectiveSuit(c) == partnerSuit)
-                .OrderByDescending(RankSort)
-                .FirstOrDefault();
-        }
-
-        protected override Card TrySignalGoodSuitFromLead(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
-            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards, string cardsPlayedInOrder = null)
-        {
-            if (trump != Suit.Unknown || isDefending)
-                return null;
-
-            if (CanCashBossCardsToCoverContract(players, bossCards))
-                return null;
-
-            var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
-            var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
-
-            if (isCurrentSeatDeclarer)
-                return null;
-
-            //  Detect self-good suits (boss / deck-top + cover + tail), pick the best suit to signal, then lead the lowest card in that suit.
-            var knownCards = cardsPlayed.Concat(new Hand(player.Hand)).ToList();
-            var candidateSignals = new List<(Suit suit, int suitCount, int rankForSuitOrdering)>();
-
-            foreach (var suitGroup in legalCards.GroupBy(EffectiveSuit))
-            {
-                var suit = suitGroup.Key;
-                var suitCards = suitGroup.OrderByDescending(RankSort).ToList();
-                if (suitCards.Count < 2)
-                    continue;
-
-                var top = suitCards[0];
-                int? rankForSuitOrdering = null;
-
-                if (IsCardHigh(top, knownCards))
-                    rankForSuitOrdering = RankSort(top);
-                else if (suitCards.Count >= 3)
-                {
-                    // If we have > 3 cards in a suit, and we determine that we can cover the top card with a stopper such
-                    // that it can become the high card, we can signal this suit by leading the lowest card in that suit.
-                    if (TopCanBeCovered(top, cardsPlayed))
-                        rankForSuitOrdering = RankSort(top);
-                }
-
-                if (rankForSuitOrdering != null)
-                    candidateSignals.Add((suit, suitCards.Count, rankForSuitOrdering.Value));
-            }
-
-            //  Choose a qualifying suit (higher rank then longest suit tiebreak); we lead the lowest legal card in that suit below.
-            var bestSuit = candidateSignals
-                .OrderByDescending(c => c.rankForSuitOrdering)
-                .ThenByDescending(c => c.suitCount)
-                .Select(c => c.suit)
-                .FirstOrDefault();
-
-            if (bestSuit != Suit.Unknown)
-            {
-                return legalCards
-                    .Where(c => EffectiveSuit(c) == bestSuit)
-                    .OrderBy(RankSort)
-                    .FirstOrDefault();
-            }
-
-            //  If we don't have any winners with cover, we lead lowest in longest suit instead of falling back to trying to take with a boss card.
-            var longestSuitGroup = legalCards
-                .GroupBy(EffectiveSuit)
-                .OrderByDescending(g => g.Count())
-                .ThenBy(g => g.Key)
-                .FirstOrDefault();
-
-            return longestSuitGroup == null
-                ? null
-                : longestSuitGroup.OrderBy(RankSort).FirstOrDefault();
-        }
-
         private int UnplayedCardCountAbove(Card c, IReadOnlyList<Card> cardsPlayed)
         {
             var suit = EffectiveSuit(c);
@@ -196,6 +94,100 @@ namespace Trickster.Bots
             return Suit.Unknown;
         }
 
+        private Card TryLeadBackInPartnerSuit(PlayerBase player, IReadOnlyList<Card> legalCards,
+            IReadOnlyList<Card> cardsPlayed, PlayersCollectionBase players, bool isDefending, string cardsPlayedInOrder)
+        {
+            if (isDefending)
+                return null;
+
+            var bossCards = legalCards.Where(c => IsCardHigh(c, cardsPlayed)).ToList();
+
+            if (CanCashBossCardsToCoverContract(players, bossCards))
+                return null;
+
+            var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
+            var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
+
+            if (isCurrentSeatDeclarer)
+                return null;
+
+            var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed, cardsPlayedInOrder);
+            if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
+                return null;
+
+            return legalCards
+                .Where(c => EffectiveSuit(c) == partnerSuit)
+                .OrderByDescending(RankSort)
+                .FirstOrDefault();
+        }
+
+        private Card TrySignalGoodSuitOnLead(PlayerBase player, IReadOnlyList<Card> legalCards,
+            IReadOnlyList<Card> cardsPlayed, PlayersCollectionBase players, bool isDefending, string cardsPlayedInOrder)
+        {
+            if (trump != Suit.Unknown || isDefending)
+                return null;
+
+            var bossCards = legalCards.Where(c => IsCardHigh(c, cardsPlayed)).ToList();
+
+            if (CanCashBossCardsToCoverContract(players, bossCards))
+                return null;
+
+            var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
+            var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
+
+            if (isCurrentSeatDeclarer)
+                return null;
+
+            var knownCards = cardsPlayed.Concat(new Hand(player.Hand)).ToList();
+            var candidateSignals = new List<(Suit suit, int suitCount, int rankForSuitOrdering)>();
+
+            foreach (var suitGroup in legalCards.GroupBy(EffectiveSuit))
+            {
+                var suit = suitGroup.Key;
+                var suitCards = suitGroup.OrderByDescending(RankSort).ToList();
+                if (suitCards.Count < 2)
+                    continue;
+
+                var top = suitCards[0];
+                int? rankForSuitOrdering = null;
+
+                if (IsCardHigh(top, knownCards))
+                    rankForSuitOrdering = RankSort(top);
+                else if (suitCards.Count >= 3)
+                {
+                    if (TopCanBeCovered(top, cardsPlayed))
+                        rankForSuitOrdering = RankSort(top);
+                }
+
+                if (rankForSuitOrdering != null)
+                    candidateSignals.Add((suit, suitCards.Count, rankForSuitOrdering.Value));
+            }
+
+            var bestSuit = candidateSignals
+                .OrderByDescending(c => c.rankForSuitOrdering)
+                .ThenByDescending(c => c.suitCount)
+                .Select(c => c.suit)
+                .FirstOrDefault();
+
+            if (bestSuit != Suit.Unknown)
+            {
+                return legalCards
+                    .Where(c => EffectiveSuit(c) == bestSuit)
+                    .OrderBy(RankSort)
+                    .FirstOrDefault();
+            }
+
+            var longestSuitGroup = legalCards
+                .GroupBy(EffectiveSuit)
+                .OrderByDescending(g => g.Count())
+                .ThenBy(g => g.Key)
+                .FirstOrDefault();
+
+            return longestSuitGroup == null
+                ? null
+                : longestSuitGroup.OrderBy(RankSort).FirstOrDefault();
+        }
+
         //  NT slough helper with some logic based on base bot's LowestCardFromWeakestSuit: pick a low discard from a weak suit.
         private Card LowestCardFromWeakestSuitNT(IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed)
         {
@@ -228,17 +220,26 @@ namespace Trickster.Bots
             return cards.OrderBy(c => cards.Count(c1 => EffectiveSuit(c1) == c.suit)).ThenBy(RankSort).First();
         }
 
-        protected override Card TrySignalGoodSuit(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, bool isDefending)
+        private Card TryNTSlough(IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, IReadOnlyList<Card> trick, bool isDefending)
         {
-            //  In no-trump, slough jokers before signaling a good suit (jokers are dead in NT)
-            if (trump == Suit.Unknown && legalCards.Any(c => c.suit == Suit.Joker))
+            if (trump != Suit.Unknown)
+                return null;
+
+            var firstCardInTrick = trick.FirstOrDefault(IsOfValue);
+            if (firstCardInTrick == null)
+                return null;
+
+            var trickSuit = EffectiveSuit(firstCardInTrick);
+            if (legalCards.Any(c => EffectiveSuit(c) == trickSuit))
+                return null;
+
+            if (legalCards.Any(c => c.suit == Suit.Joker))
                 return legalCards.First(c => c.suit == Suit.Joker);
 
-            //  NT offense: dump from weakest suit rather than signaling strong suit
-            if (trump == Suit.Unknown && !isDefending)
+            if (!isDefending)
                 return LowestCardFromWeakestSuitNT(legalCards, cardsPlayed);
 
-            return base.TrySignalGoodSuit(player, legalCards, cardsPlayed, isDefending);
+            return null;
         }
 
         public override BidBase SuggestBid(SuggestBidState<WhistOptions> state)
@@ -340,34 +341,53 @@ namespace Trickster.Bots
         public override Card SuggestNextCard(SuggestCardState<WhistOptions> state)
         {
             var bid = new WhistBid(state.player.Bid);
+            var isDefending = !bid.IsDeclareBid && !bid.IsDeclarePartnerBid;
             var legalCards = state.legalCards;
+            var players = new PlayersCollectionBase(this, state.players);
 
-            // Avoid leading Jokers or suits partner is known to be void in NT
-            if (state.trick.Count == 0 && state.trumpSuit == Suit.Unknown) {
-                if (legalCards.Any(c => c.suit == Suit.Joker) && legalCards.Any(c => c.suit != Suit.Joker))
+            if (state.trick.Count == 0)
+            {
+                if (state.trumpSuit == Suit.Unknown)
                 {
-                    legalCards = legalCards.Where(c => c.suit != Suit.Joker).ToList();
+                    if (legalCards.Any(c => c.suit == Suit.Joker) && legalCards.Any(c => c.suit != Suit.Joker))
+                    {
+                        legalCards = legalCards.Where(c => c.suit != Suit.Joker).ToList();
+                    }
+
+                    var avoidPartnerVoidSuits = SuitRank.stdSuits.Where(s =>
+                        players.PartnerIsVoidInSuit(state.player, new Card(s, Rank.Ace), state.cardsPlayed)).ToList();
+                    if (avoidPartnerVoidSuits.Count > 0)
+                    {
+                        var withoutPartnerVoidLead = legalCards.Where(c =>
+                            !avoidPartnerVoidSuits.Contains(EffectiveSuit(c)) || IsCardHigh(c, state.cardsPlayed)).ToList();
+                        if (withoutPartnerVoidLead.Count > 0)
+                            legalCards = withoutPartnerVoidLead;
+                    }
                 }
-                var players = new PlayersCollectionBase(this, state.players);
-                var avoidPartnerVoidSuits = SuitRank.stdSuits.Where(s =>
-                    players.PartnerIsVoidInSuit(state.player, new Card(s, Rank.Ace), state.cardsPlayed)).ToList();
-                if (avoidPartnerVoidSuits.Count > 0)
-                {
-                    var withoutPartnerVoidLead = legalCards.Where(c =>
-                        !avoidPartnerVoidSuits.Contains(EffectiveSuit(c)) || IsCardHigh(c, state.cardsPlayed)).ToList();
-                    if (withoutPartnerVoidLead.Count > 0)
-                        legalCards = withoutPartnerVoidLead;
-                }
+
+                var leadBack = TryLeadBackInPartnerSuit(state.player, legalCards, state.cardsPlayed, players, isDefending, state.cardsPlayedInOrder);
+                if (leadBack != null)
+                    return leadBack;
+
+                var signal = TrySignalGoodSuitOnLead(state.player, legalCards, state.cardsPlayed, players, isDefending, state.cardsPlayedInOrder);
+                if (signal != null)
+                    return signal;
+            }
+            else
+            {
+                var slough = TryNTSlough(legalCards, state.cardsPlayed, state.trick, isDefending);
+                if (slough != null)
+                    return slough;
             }
 
             return TryTakeEm(state.player,
                 state.trick,
                 legalCards,
                 state.cardsPlayed,
-                new PlayersCollectionBase(this, state.players),
+                players,
                 state.isPartnerTakingTrick,
                 state.cardTakingTrick,
-                !bid.IsDeclareBid && !bid.IsDeclarePartnerBid,
+                isDefending,
                 state.cardsPlayedInOrder);
         }
 

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -225,8 +225,19 @@ namespace Trickster.Bots
                     return low;
             }
 
-            //  return the lowest card from the shortest suit
-            return cards.OrderBy(c => cards.Count(c1 => EffectiveSuit(c1) == c.suit)).ThenBy(RankSort).First();
+            //  try to slough from suits with 3+ cards to avoid hitting unsuitable cards in the singleton/doubleton logic above
+            var longerSuitCards = cards.Where(c => suitCounts.Any(sc => sc.suit == EffectiveSuit(c) && sc.count >= 3)).ToList();
+
+            if (longerSuitCards.Any())
+                return longerSuitCards.OrderBy(c => longerSuitCards.Count(c1 => EffectiveSuit(c1) == EffectiveSuit(c))).ThenBy(RankSort).First();
+
+            //  nothing with 3+ cards left; prefer low from a doubleton over a singleton
+            var doubletonCards = cards.Where(c => suitCounts.Any(sc => sc.suit == EffectiveSuit(c) && sc.count == 2)).ToList();
+
+            if (doubletonCards.Any())
+                return doubletonCards.OrderBy(RankSort).First();
+
+            return cards.OrderBy(RankSort).First();
         }
 
         private Card TryNTSlough(IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed, IReadOnlyList<Card> trick, bool isDefending)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -121,6 +121,7 @@ namespace Trickster.Bots
                     .OrderBy(RankSort)
                     .FirstOrDefault();
             } else if (isPartnerDeclarer) {
+                // Offensive partner: lead the highest card in partner's suit to show strength.
                 return legalCards
                     .Where(c => EffectiveSuit(c) == partnerSuit)
                     .OrderByDescending(RankSort)
@@ -147,6 +148,7 @@ namespace Trickster.Bots
             if (isCurrentSeatDeclarer)
                 return null;
 
+            //  Detect self-good suits (boss / deck-top + cover + tail), pick the best suit to signal, then lead the lowest card in that suit.
             var knownCards = cardsPlayed.Concat(new Hand(player.Hand)).ToList();
             var candidateSignals = new List<(Suit suit, int suitCount, int rankForSuitOrdering)>();
 
@@ -164,6 +166,8 @@ namespace Trickster.Bots
                     rankForSuitOrdering = RankSort(top);
                 else if (suitCards.Count >= 3)
                 {
+                    // If we have > 3 cards in a suit, and we determine that we can cover the top card with a stopper such
+                    // that it can become the high card, we can signal this suit by leading the lowest card in that suit.
                     if (TopCanBeCovered(top, cardsPlayed))
                         rankForSuitOrdering = RankSort(top);
                 }
@@ -172,6 +176,7 @@ namespace Trickster.Bots
                     candidateSignals.Add((suit, suitCards.Count, rankForSuitOrdering.Value));
             }
 
+            //  Choose a qualifying suit (higher rank then longest suit tiebreak); we lead the lowest legal card in that suit below.
             var bestSuit = candidateSignals
                 .OrderByDescending(c => c.rankForSuitOrdering)
                 .ThenByDescending(c => c.suitCount)
@@ -186,6 +191,7 @@ namespace Trickster.Bots
                     .FirstOrDefault();
             }
 
+            //  If we don't have any winners with cover, we lead lowest in longest suit instead of falling back to trying to take with a boss card.
             var longestSuitGroup = legalCards
                 .GroupBy(EffectiveSuit)
                 .OrderByDescending(g => g.Count())


### PR DESCRIPTION
Based on some feedback we got on recent bot improvements: When on offense, slough suggestions should shed weak cards from weak suits (indicating where partner should not return to) instead of signaling strong suits.

Based on previous conversation, this PR also performs a refactor of some logic that was added to the TryLeadTowardPartnerIntroducedSuit, TrySignalGoodSuitFromLead hooks in TryTakeEm extended by only whistbot and moves them instead to private helpers called by the whist specific SuggestNextCard before falling through to TryTakeEm. It additionally moves the logic out of TrySignalGoodSuit that was in fact signaling a bad suit into a new NTSlough related method also called from SuggestNextCard