### PR TITLE
500: Avoid signaling with singleton boss card

### DIFF
--- a/TestBots/TestFiveHundredBot.cs
+++ b/TestBots/TestFiveHundredBot.cs
@@ -203,6 +203,26 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void SignalGoodSuitAvoidsSingletonAce()
+        {
+            var players = new[]
+            {
+                new TestPlayer(FiveHundredBid.ContractorPartnerBid, "ACTH9H8H7S4S3S2S"),
+                new TestPlayer(FiveHundredBid.NotContractorBid, "0?0?0?0?0?0?0?0?0?"),
+                new TestPlayer(new FiveHundredBid(Suit.Hearts, 7), "0?0?0?0?0?0?0?0?0?"),
+                new TestPlayer(FiveHundredBid.NotContractorBid, "0?0?0?0?0?0?0?0?0?"),
+            };
+            var bot = GetBot(Suit.Hearts, defaultOptions);
+            var cardState = new TestCardState<FiveHundredOptions>(
+                bot,
+                players,
+                trick: "ADTD"
+            );
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("2S", $"{suggestion}");
+        }
+
+        [TestMethod]
         public void PlayHighIn3rdIfMisereIsUnder()
         {
             var players = new[]

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -557,12 +557,12 @@ namespace Trickster.Bots
             if (legalCards.All(IsTrump))
                 return null;
 
-            //  otherwise try to signal a suit where we hold boss and at least one other card, or where we hold a singleton and at least one trump
+            //  otherwise try to signal a suit where we hold boss and at least one other card, or where we hold a non-boss singleton and at least one trump
             var hasTrump = legalCards.Any(IsTrump);
             var suitRange = legalCards.Where(c => !IsTrump(c)).OrderBy(RankSort).GroupBy(EffectiveSuit)
                 .Select(g => new { suit = g.Key, low = g.First(), high = g.Last() }).ToList();
             var signalableSuit = suitRange.FirstOrDefault(sr => sr.high != sr.low && IsCardHigh(sr.high, cardsPlayed))
-                                 ?? suitRange.FirstOrDefault(sr => sr.low == sr.high && hasTrump);
+                                 ?? suitRange.FirstOrDefault(sr => sr.low == sr.high && hasTrump && !IsCardHigh(sr.high, cardsPlayed));
 
             return signalableSuit?.low;
         }


### PR DESCRIPTION
Prevents the bot from throwing away a likely trick. The TrySignalGoodSuit logic was missing a check if a singleton was boss (the highest remaining card) in the suit.