### PR TITLE
Leadback suit indicating strength as whist NT offensive partner

### DIFF
--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -338,6 +338,25 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void LeadSignalFromLead_NT_LeadsLowestFromLongestSuitFallback()
+        {
+            // No partner-introduced suit, no qualifying "good suit" signal pattern, but we still choose a lead inside
+            // TrySignalGoodSuitFromLead: lowest card in the longest suit (before TryTakeEm would cash a boss).
+            var players = new[]
+            {
+                new TestPlayer(DeclarersPartnerSeatBid, "3D4D5D3H2HAS", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("3D", suggestion.ToString(), "Longest suit is diamonds; lead lowest there, not spade boss");
+        }
+
+        [TestMethod]
         public void SkipLeadTowardPartnerWhenBossCardsCoverRemainingContract_NT()
         {
             var partnerHeartBid = new WhistBid(Suit.Hearts, 3, true, false);

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -270,6 +270,74 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void LeadSignalFromLead_NT_LeadsHighestBelowTop()
+        {
+            var players = new[]
+            {
+                new TestPlayer(1561, "AH9H3HAS", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                new TestPlayer(1401, seat: 2),
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("9H", suggestion.ToString(), "With no partner suit to lead back, lead highest below boss top when suit has length");
+        }
+
+        [TestMethod]
+        public void LeadSignalFromLead_NT_BossAndCoverLeadsLowerCard()
+        {
+            var players = new[]
+            {
+                new TestPlayer(1561, "AH3HAS", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                new TestPlayer(1401, seat: 2),
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("3H", suggestion.ToString(), "Doubleton with deck-top boss may signal by leading the lower card");
+        }
+
+        [TestMethod]
+        public void LeadSignalFromLead_NT_KingDoubletonDoesNotUnstopSuit()
+        {
+            var players = new[]
+            {
+                new TestPlayer(1561, "KH3HAS", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                new TestPlayer(1401, seat: 2),
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("AS", suggestion.ToString(), "Do not lead from king-doubleton because it strips the stopper");
+        }
+
+        [TestMethod]
+        public void LeadSignalFromLead_NT_KingStopperTripletonLeadsHighestNonTop()
+        {
+            var players = new[]
+            {
+                new TestPlayer(1561, "KHQH3HAS", seat: 0),
+                new TestPlayer(1400, seat: 1),
+                new TestPlayer(1401, seat: 2),
+                new TestPlayer(1400, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("QH", suggestion.ToString(), "With top + stopper cover + one more, lead the highest non-top card");
+        }
+
+        [TestMethod]
         public void SkipLeadTowardPartnerWhenBossCardsCoverRemainingContract_NT()
         {
             var partnerHeartBid = new WhistBid(Suit.Hearts, 3, true, false);

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -274,10 +274,10 @@ namespace TestBots
         {
             var players = new[]
             {
-                new TestPlayer(1561, "AH9H3HAS", seat: 0),
-                new TestPlayer(1400, seat: 1),
-                new TestPlayer(1401, seat: 2),
-                new TestPlayer(1400, seat: 3)
+                new TestPlayer(DeclarersPartnerSeatBid, "AH9H3HAS", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);
@@ -291,10 +291,10 @@ namespace TestBots
         {
             var players = new[]
             {
-                new TestPlayer(1561, "AH3HAS", seat: 0),
-                new TestPlayer(1400, seat: 1),
-                new TestPlayer(1401, seat: 2),
-                new TestPlayer(1400, seat: 3)
+                new TestPlayer(DeclarersPartnerSeatBid, "AH3HAS", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);
@@ -308,16 +308,16 @@ namespace TestBots
         {
             var players = new[]
             {
-                new TestPlayer(1561, "KH3HAS", seat: 0),
-                new TestPlayer(1400, seat: 1),
-                new TestPlayer(1401, seat: 2),
-                new TestPlayer(1400, seat: 3)
+                new TestPlayer(DeclarersPartnerSeatBid, "KH3HQS6S5S", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
             var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("AS", suggestion.ToString(), "Do not lead from king-doubleton because it strips the stopper");
+            Assert.AreEqual("5S", suggestion.ToString(), "Do not lead from king-doubleton because it strips the stopper");
         }
 
         [TestMethod]
@@ -325,10 +325,10 @@ namespace TestBots
         {
             var players = new[]
             {
-                new TestPlayer(1561, "KHQH3HAS", seat: 0),
-                new TestPlayer(1400, seat: 1),
-                new TestPlayer(1401, seat: 2),
-                new TestPlayer(1400, seat: 3)
+                new TestPlayer(DeclarersPartnerSeatBid, "KHQH3HAS", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
             };
 
             var bot = GetBot(Suit.Unknown);

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -270,7 +270,7 @@ namespace TestBots
         }
 
         [TestMethod]
-        public void LeadSignalFromLead_NT_LeadsHighestBelowTop()
+        public void LeadSignalFromLead_NT_LeadsLowestFromSelectedSuit()
         {
             var players = new[]
             {
@@ -283,7 +283,7 @@ namespace TestBots
             var bot = GetBot(Suit.Unknown);
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
             var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("9H", suggestion.ToString(), "With no partner suit to lead back, lead highest below boss top when suit has length");
+            Assert.AreEqual("3H", suggestion.ToString(), "With no partner suit to lead back, select the good suit and lead lowest in it");
         }
 
         [TestMethod]
@@ -321,7 +321,7 @@ namespace TestBots
         }
 
         [TestMethod]
-        public void LeadSignalFromLead_NT_KingStopperTripletonLeadsHighestNonTop()
+        public void LeadSignalFromLead_NT_KingStopperTripletonLeadsLowestInGoodSuit()
         {
             var players = new[]
             {
@@ -334,7 +334,7 @@ namespace TestBots
             var bot = GetBot(Suit.Unknown);
             var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown);
             var suggestion = bot.SuggestNextCard(cardState);
-            Assert.AreEqual("QH", suggestion.ToString(), "With top + stopper cover + one more, lead the highest non-top card");
+            Assert.AreEqual("3H", suggestion.ToString(), "With top + stopper cover + one more, lead the lowest card in the selected good suit");
         }
 
         [TestMethod]

--- a/TricksterBots/Bots/BaseBot.cs
+++ b/TricksterBots/Bots/BaseBot.cs
@@ -322,6 +322,13 @@ namespace Trickster.Bots
             return null;
         }
 
+        //  Override in game-specific bots that need lead-time suit signaling behavior
+        protected virtual Card TrySignalGoodSuitFromLead(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
+            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards, string cardsPlayedInOrder = null)
+        {
+            return null;
+        }
+
         //  NOTE: If you're going to edit this in a game-specific way, copy the method to your bot and edit it there
         protected Card TryTakeEm(PlayerBase player, IReadOnlyList<Card> trick, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
             PlayersCollectionBase players, bool isPartnerTakingTrick,
@@ -402,6 +409,11 @@ namespace Trickster.Bots
                     .OrderByDescending(c => cards.Count(c1 => EffectiveSuit(c1) == EffectiveSuit(c))).ToList();
 
                 suggestion = TryLeadTowardPartnerIntroducedSuit(player, legalCards, cardsPlayed, players, isDefending, bossCards, cardsPlayedInOrder);
+                if (suggestion != null)
+                {
+                    return suggestion;
+                }
+                suggestion = TrySignalGoodSuitFromLead(player, legalCards, cardsPlayed, players, isDefending, bossCards, cardsPlayedInOrder);
                 if (suggestion != null)
                 {
                     return suggestion;

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -52,57 +52,69 @@ namespace Trickster.Bots
             if (CanCashBossCardsToCoverContract(players, bossCards))
                 return null;
 
-            //  Lead back from a self-good suit: highest card below a preserved stopper (boss / deck-top + cover + tail).
-            var knownCards = cardsPlayed.Concat(new Hand(player.Hand)).ToList();
-            var candidateSignals = new List<(Suit suit, int suitCount, int signalRank)>();
+            var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
+            var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
 
-            foreach (var suitGroup in legalCards
-                         .Where(c => c.suit != Suit.Joker)
-                         .GroupBy(EffectiveSuit))
+            if (isCurrentSeatDeclarer)
+                return null;
+
+            //  Detect self-good suits (boss / deck-top + cover + tail), pick the best suit to signal, then lead the lowest card in that suit.
+            var knownCards = cardsPlayed.Concat(new Hand(player.Hand)).ToList();
+            var candidateSignals = new List<(Suit suit, int suitCount, int rankForSuitOrdering)>();
+
+            foreach (var suitGroup in legalCards.GroupBy(EffectiveSuit))
             {
+                var suit = suitGroup.Key;
                 var suitCards = suitGroup.OrderByDescending(RankSort).ToList();
                 if (suitCards.Count < 2)
                     continue;
-                
-                var top = suitCards[0];
-                Card lead = null;
 
-                //  If we have highest + 1 more, lead the highest non-top card.
-                if (lead == null && IsCardHigh(top, knownCards))
+                var top = suitCards[0];
+                int? rankForSuitOrdering = null;
+
+                if (rankForSuitOrdering == null && IsCardHigh(top, knownCards))
                 {
                     var holdsDeckTopRank = RankSort(top) == HighRankInSuit(top);
                     if (holdsDeckTopRank)
-                        lead = suitCards[1];
+                        rankForSuitOrdering = RankSort(suitCards[1]);
                 }
 
-                //  With top + stopper cover + one more card, lead the highest non-top card.
                 if (suitCards.Count >= 3)
                 {
                     var cover = suitCards[1];
                     if (IsCardEffectivelyTheSame(cover, top, knownCards))
-                        lead = suitCards[1];
+                        rankForSuitOrdering = RankSort(cover);
                 }
 
-                
-
-                if (lead != null)
-                    candidateSignals.Add((EffectiveSuit(lead), suitCards.Count, RankSort(lead)));
+                if (rankForSuitOrdering != null)
+                    candidateSignals.Add((suit, suitCards.Count, rankForSuitOrdering.Value));
             }
 
-            // pick the next best suit to lead back in
+            //  Choose a qualifying suit (longest first, then higher tie-break rank); we lead the lowest legal card in that suit below.
             var bestSuit = candidateSignals
                 .OrderByDescending(c => c.suitCount)
-                .ThenByDescending(c => c.signalRank)
+                .ThenByDescending(c => c.rankForSuitOrdering)
                 .Select(c => c.suit)
                 .FirstOrDefault();
 
-            // Return the lowest card in selected suit
-            return bestSuit == Suit.Unknown
-                ? null
-                : legalCards
+            if (bestSuit != Suit.Unknown)
+            {
+                return legalCards
                     .Where(c => EffectiveSuit(c) == bestSuit)
                     .OrderBy(RankSort)
                     .FirstOrDefault();
+            }
+
+            //  If we don't have any winners with cover, we lead lowest in longest suit instead of falling back to trying to take with a boss card.
+            var longestSuitGroup = legalCards
+                .GroupBy(EffectiveSuit)
+                .OrderByDescending(g => g.Count())
+                .ThenBy(g => g.Key)
+                .FirstOrDefault();
+
+            return longestSuitGroup == null
+                ? null
+                : longestSuitGroup.OrderBy(RankSort).FirstOrDefault();
         }
 
         private static int TricksTaken(PlayerBase player)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -54,7 +54,7 @@ namespace Trickster.Bots
 
             //  Lead back from a self-good suit: highest card below a preserved stopper (boss / deck-top + cover + tail).
             var knownCards = cardsPlayed.Concat(new Hand(player.Hand)).ToList();
-            var candidateSignals = new List<(Card lead, int suitCount)>();
+            var candidateSignals = new List<(Suit suit, int suitCount, int signalRank)>();
 
             foreach (var suitGroup in legalCards
                          .Where(c => c.suit != Suit.Joker)
@@ -86,14 +86,23 @@ namespace Trickster.Bots
                 
 
                 if (lead != null)
-                    candidateSignals.Add((lead, suitCards.Count));
+                    candidateSignals.Add((EffectiveSuit(lead), suitCards.Count, RankSort(lead)));
             }
 
-            return candidateSignals
+            // pick the next best suit to lead back in
+            var bestSuit = candidateSignals
                 .OrderByDescending(c => c.suitCount)
-                .ThenByDescending(c => RankSort(c.lead))
-                .Select(c => c.lead)
+                .ThenByDescending(c => c.signalRank)
+                .Select(c => c.suit)
                 .FirstOrDefault();
+
+            // Return the lowest card in selected suit
+            return bestSuit == Suit.Unknown
+                ? null
+                : legalCards
+                    .Where(c => EffectiveSuit(c) == bestSuit)
+                    .OrderBy(RankSort)
+                    .FirstOrDefault();
         }
 
         private static int TricksTaken(PlayerBase player)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -73,17 +73,13 @@ namespace Trickster.Bots
                 int? rankForSuitOrdering = null;
 
                 if (IsCardHigh(top, knownCards))
+                    rankForSuitOrdering = RankSort(top);
+                else if (suitCards.Count >= 3)
                 {
-                    var holdsDeckTopRank = RankSort(top) == HighRankInSuit(top);
-                    if (holdsDeckTopRank)
-                        rankForSuitOrdering = RankSort(suitCards[1]);
-                }
-
-                if (suitCards.Count >= 3)
-                {
-                    var cover = suitCards[1];
-                    if (IsCardEffectivelyTheSame(cover, top, knownCards))
-                        rankForSuitOrdering = RankSort(cover);
+                    // If we have > 3 cards in a suit, and we determine that we can cover the top card with a stopper such
+                    // that it can become the high card, we can signal this suit by leading the lowest card in that suit.
+                    if (TopCanBeCovered(top, cardsPlayed))
+                        rankForSuitOrdering = RankSort(top);
                 }
 
                 if (rankForSuitOrdering != null)
@@ -115,6 +111,16 @@ namespace Trickster.Bots
             return longestSuitGroup == null
                 ? null
                 : longestSuitGroup.OrderBy(RankSort).FirstOrDefault();
+        }
+
+        private bool TopCanBeCovered(Card top, IReadOnlyList<Card> cardsPlayed)
+        {
+            var suit = EffectiveSuit(top);
+            var topRank = RankSort(top);
+            var highestInSuit = HighRankInSuit(top);
+            var rankGapToDeckTop = highestInSuit - topRank;
+            var playedAboveTop = cardsPlayed.Count(c => EffectiveSuit(c) == suit && RankSort(c) > topRank);
+            return rankGapToDeckTop - playedAboveTop <= 1;
         }
 
         private static int TricksTaken(PlayerBase player)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -72,7 +72,7 @@ namespace Trickster.Bots
                 var top = suitCards[0];
                 int? rankForSuitOrdering = null;
 
-                if (rankForSuitOrdering == null && IsCardHigh(top, knownCards))
+                if (IsCardHigh(top, knownCards))
                 {
                     var holdsDeckTopRank = RankSort(top) == HighRankInSuit(top);
                     if (holdsDeckTopRank)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -22,19 +22,11 @@ namespace Trickster.Bots
 
             //  If we already have enough "boss" cards left to make our team's bid,
             //  just let them play out rather than trying to come back in partner's suit.
-            var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
-            var declarersPartner = declarer != null ? players.PartnerOf(declarer) : null;
-            var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
-            if (declarer != null)
-            {
-                var contract = new WhistBid(declarer.Bid);
-                var tricksTaken = declarer.CardsTaken.Length / 8;
-                if (declarersPartner != null)
-                    tricksTaken += declarersPartner.CardsTaken.Length / 8;
+            if (CanCashBossCardsToCoverContract(players, bossCards))
+                return null;
 
-                if (tricksTaken + bossCards.Count >= contract.Tricks)
-                    return null;
-            }
+            var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
+            var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
 
             if (isCurrentSeatDeclarer)
                 return null;
@@ -49,6 +41,79 @@ namespace Trickster.Bots
                 .Where(c => EffectiveSuit(c) == partnerSuit)
                 .OrderByDescending(RankSort)
                 .FirstOrDefault();
+        }
+
+        protected override Card TrySignalGoodSuitFromLead(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,
+            PlayersCollectionBase players, bool isDefending, IReadOnlyList<Card> bossCards, string cardsPlayedInOrder = null)
+        {
+            if (trump != Suit.Unknown || isDefending)
+                return null;
+
+            if (CanCashBossCardsToCoverContract(players, bossCards))
+                return null;
+
+            //  Lead back from a self-good suit: highest card below a preserved stopper (boss / deck-top + cover + tail).
+            var knownCards = cardsPlayed.Concat(new Hand(player.Hand)).ToList();
+            var candidateSignals = new List<(Card lead, int suitCount)>();
+
+            foreach (var suitGroup in legalCards
+                         .Where(c => c.suit != Suit.Joker)
+                         .GroupBy(EffectiveSuit))
+            {
+                var suitCards = suitGroup.OrderByDescending(RankSort).ToList();
+                if (suitCards.Count < 2)
+                    continue;
+                
+                var top = suitCards[0];
+                Card lead = null;
+
+                //  If we have highest + 1 more, lead the highest non-top card.
+                if (lead == null && IsCardHigh(top, knownCards))
+                {
+                    var holdsDeckTopRank = RankSort(top) == HighRankInSuit(top);
+                    if (holdsDeckTopRank)
+                        lead = suitCards[1];
+                }
+
+                //  With top + stopper cover + one more card, lead the highest non-top card.
+                if (suitCards.Count >= 3)
+                {
+                    var cover = suitCards[1];
+                    if (IsCardEffectivelyTheSame(cover, top, knownCards))
+                        lead = suitCards[1];
+                }
+
+                
+
+                if (lead != null)
+                    candidateSignals.Add((lead, suitCards.Count));
+            }
+
+            return candidateSignals
+                .OrderByDescending(c => c.suitCount)
+                .ThenByDescending(c => RankSort(c.lead))
+                .Select(c => c.lead)
+                .FirstOrDefault();
+        }
+
+        private static int TricksTaken(PlayerBase player)
+        {
+            return string.IsNullOrEmpty(player.CardsTaken) ? 0 : player.CardsTaken.Length / 8;
+        }
+
+        private bool CanCashBossCardsToCoverContract(PlayersCollectionBase players, IReadOnlyList<Card> bossCards)
+        {
+            var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
+            if (declarer == null)
+                return false;
+
+            var contract = new WhistBid(declarer.Bid);
+            var partner = players.PartnerOf(declarer);
+            var tricksTaken = TricksTaken(declarer);
+            if (partner != null)
+                tricksTaken += TricksTaken(partner);
+
+            return tricksTaken + bossCards.Count >= contract.Tricks;
         }
 
         private Suit PartnerIntroducedSuitFromAuctionAndSignal(PlayerBase player, PlayersCollectionBase players, IReadOnlyList<Card> cardsPlayed,

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -86,10 +86,10 @@ namespace Trickster.Bots
                     candidateSignals.Add((suit, suitCards.Count, rankForSuitOrdering.Value));
             }
 
-            //  Choose a qualifying suit (longest first, then higher tie-break rank); we lead the lowest legal card in that suit below.
+            //  Choose a qualifying suit (higher rank then longest suit tiebreak); we lead the lowest legal card in that suit below.
             var bestSuit = candidateSignals
-                .OrderByDescending(c => c.suitCount)
-                .ThenByDescending(c => c.rankForSuitOrdering)
+                .OrderByDescending(c => c.rankForSuitOrdering)
+                .ThenByDescending(c => c.suitCount)
                 .Select(c => c.suit)
                 .FirstOrDefault();
 


### PR DESCRIPTION
Follow up to https://github.com/TricksterCards/TricksterBots/pull/381 

If a bot is on offense and partner has bid NT, we first try and come back in Partner's suit. However, if we don't have any available cards in that suit, we then fall back to a new method TrySignalGoodSuitFromLead -> which in BidWhist indicates to a partner a suit that a bot has a boss (or potential boss) card in by leading the highest non-boss card in that suit back.

If it does not have a boss with cover, it leads lowest from the longest suit instead of falling back to trying to take tricks