### PR TITLE
NT bidder: Lead back in partner good suit

### DIFF
--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -213,7 +213,7 @@ namespace TestBots
         }
 
         [TestMethod]
-        public void LeadBackPartnerGoodSuit_NT_DeclarerLeadsLowest()
+        public void LeadBackPartnerGoodSuit_NT_BidderLeadsLowest()
         {
             var declarerNtBid = (int)new WhistBid(Suit.Unknown, 1, true, false);
             var players = new[]

--- a/TestBots/TestWhistBot.cs
+++ b/TestBots/TestWhistBot.cs
@@ -213,6 +213,27 @@ namespace TestBots
         }
 
         [TestMethod]
+        public void LeadBackPartnerGoodSuit_NT_DeclarerLeadsLowest()
+        {
+            var declarerNtBid = (int)new WhistBid(Suit.Unknown, 1, true, false);
+            var players = new[]
+            {
+                new TestPlayer(declarerNtBid, "5H8H2C3C", seat: 0),
+                new TestPlayer(BidBase.NoBid, seat: 1),
+                new TestPlayer(DeclarersPartnerSeatBid, "", seat: 2),
+                new TestPlayer(BidBase.NoBid, seat: 3)
+            };
+
+            var bot = GetBot(Suit.Unknown);
+            var cardState = new TestCardState<WhistOptions>(bot, players, trumpSuit: Suit.Unknown)
+            {
+                cardsPlayedInOrder = "23H32H0AS1KH"
+            };
+            var suggestion = bot.SuggestNextCard(cardState);
+            Assert.AreEqual("5H", suggestion.ToString(), "NT declarer with no bosses leads lowest back in suit partner signaled from the lead");
+        }
+
+        [TestMethod]
         public void LeadBackSuitPartnerTriedToPromote_NT()
         {
             var players = new[]

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -28,15 +28,23 @@ namespace Trickster.Bots
             var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
             var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
 
-            if (isCurrentSeatDeclarer)
-                return null;
-
             var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed, cardsPlayedInOrder);
             if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
                 return null;
 
-            // If we have cards in the partner's suit, lead the highest card in that suit to indicate
-            // to partner what our hand looks like.
+            if (isCurrentSeatDeclarer)
+            {
+                //  NT declarer with no bosses: come back in the suit partner signaled from the lead (lowest card).
+                if (trump != Suit.Unknown || bossCards.Count > 0)
+                    return null;
+
+                return legalCards
+                    .Where(c => EffectiveSuit(c) == partnerSuit)
+                    .OrderBy(RankSort)
+                    .FirstOrDefault();
+            }
+
+            //  Offensive partner: lead the highest card in partner's suit to show strength.
             return legalCards
                 .Where(c => EffectiveSuit(c) == partnerSuit)
                 .OrderByDescending(RankSort)

--- a/TricksterBots/Bots/Whist/WhistBot.cs
+++ b/TricksterBots/Bots/Whist/WhistBot.cs
@@ -27,28 +27,29 @@ namespace Trickster.Bots
 
             var declarer = players.FirstOrDefault(p => new WhistBid(p.Bid).IsDeclareBid);
             var isCurrentSeatDeclarer = player.Seat == declarer?.Seat;
+            var isPartnerDeclarer = declarer != null && players.PartnerOf(player)?.Seat == declarer.Seat;
 
             var partnerSuit = PartnerIntroducedSuitFromAuctionAndSignal(player, players, cardsPlayed, cardsPlayedInOrder);
             if (partnerSuit == Suit.Unknown || !legalCards.Any(c => EffectiveSuit(c) == partnerSuit))
                 return null;
 
-            if (isCurrentSeatDeclarer)
-            {
-                //  NT declarer with no bosses: come back in the suit partner signaled from the lead (lowest card).
-                if (trump != Suit.Unknown || bossCards.Count > 0)
-                    return null;
 
+            if (isCurrentSeatDeclarer && trump == Suit.Unknown)
+            {
+                //  NT declarer: come back in the suit partner signaled from the lead (lowest card).
                 return legalCards
                     .Where(c => EffectiveSuit(c) == partnerSuit)
                     .OrderBy(RankSort)
                     .FirstOrDefault();
+            } else if (isPartnerDeclarer) {
+                // Offensive partner: lead the highest card in partner's suit to show strength.
+                return legalCards
+                    .Where(c => EffectiveSuit(c) == partnerSuit)
+                    .OrderByDescending(RankSort)
+                    .FirstOrDefault();
             }
 
-            //  Offensive partner: lead the highest card in partner's suit to show strength.
-            return legalCards
-                .Where(c => EffectiveSuit(c) == partnerSuit)
-                .OrderByDescending(RankSort)
-                .FirstOrDefault();
+            return null;
         }
 
         protected override Card TrySignalGoodSuitFromLead(PlayerBase player, IReadOnlyList<Card> legalCards, IReadOnlyList<Card> cardsPlayed,


### PR DESCRIPTION
Follow up to #385 . This PR updates the TryLeadTowardPartnerIntroducedSuit hook in the whistbot such that it takes into account a good suit that the partner has led in previous hands. Note: this only occurs if they do not have any boss cards to play